### PR TITLE
feat: safe redirect — Redirect() relative-only, RedirectExternal() with host allowlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,37 @@ func main() {
 }
 ```
 
+## Safe Redirect
+
+`ctx.Redirect()` only accepts relative paths. For redirecting to external hosts, use `ctx.RedirectExternal()` with an explicit allowlist.
+
+```go
+type Bindings struct {
+    AllowedRedirectHosts []string
+}
+
+type MyContext = interfaces.IContext[Bindings]
+
+func main() {
+    bindings := &Bindings{
+        AllowedRedirectHosts: []string{"auth.example.com"},
+    }
+
+    app := takibi.New(bindings)
+
+    // relative redirect — always safe
+    app.Get("/dashboard", func(ctx MyContext) error {
+        return ctx.Redirect("/home")
+    })
+
+    // external redirect — host validated against allowlist
+    app.Get("/oauth/callback", func(ctx MyContext) error {
+        next := ctx.Req().QueryBy("next")
+        return ctx.RedirectExternal(next, ctx.Env().AllowedRedirectHosts)
+    })
+}
+```
+
 ## Document
 
 docs link

--- a/context.go
+++ b/context.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
+	"slices"
 	"strings"
 
 	"github.com/poteto0/takibi/interfaces"
@@ -91,9 +93,28 @@ func (c *context[Bindings]) Json(data any) error {
 	return json.NewEncoder(c.response).Encode(data)
 }
 
-func (c *context[Bindings]) Redirect(url string) error {
-	http.Redirect(c.response, c.request.Raw(), url, http.StatusFound)
+func (c *context[Bindings]) Redirect(path string) error {
+	parsed, err := url.Parse(path)
+	if err == nil && parsed.Host != "" {
+		return fmt.Errorf("redirect: absolute URLs are not allowed, use RedirectExternal")
+	}
+	http.Redirect(c.response, c.request.Raw(), path, http.StatusFound)
 	return nil
+}
+
+func (c *context[Bindings]) RedirectExternal(rawURL string, allowedHosts []string) error {
+	if len(allowedHosts) == 0 {
+		return fmt.Errorf("redirect: allowedHosts must not be empty")
+	}
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("redirect: invalid URL: %w", err)
+	}
+	if slices.Contains(allowedHosts, parsed.Hostname()) {
+		http.Redirect(c.response, c.request.Raw(), rawURL, http.StatusFound)
+		return nil
+	}
+	return fmt.Errorf("redirect: host %q is not in the allowlist", parsed.Hostname())
 }
 
 func (c *context[Bindings]) Render(config *interfaces.RenderConfig) error {

--- a/context_test.go
+++ b/context_test.go
@@ -115,14 +115,80 @@ func TestContext_Response(t *testing.T) {
 	})
 
 	t.Run("check redirect method", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "/", nil)
-		w := httptest.NewRecorder()
-		ctx := NewContext[any](w, req, nil)
+		tests := []struct {
+			name    string
+			path    string
+			wantErr bool
+		}{
+			{"relative path", "/redirect", false},
+			{"relative path with query", "/redirect?foo=bar", false},
+			{"absolute URL rejected", "https://evil.example.com/steal", true},
+			{"protocol-relative URL rejected", "//evil.example.com", true},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				req := httptest.NewRequest(http.MethodGet, "/", nil)
+				w := httptest.NewRecorder()
+				ctx := NewContext[any](w, req, nil)
 
-		err := ctx.Redirect("/redirect")
-		assert.Nil(t, err)
-		assert.Equal(t, http.StatusFound, w.Code)
-		assert.Equal(t, "/redirect", w.Header().Get("Location"))
+				err := ctx.Redirect(tt.path)
+				if tt.wantErr {
+					assert.Error(t, err)
+					return
+				}
+				assert.Nil(t, err)
+				assert.Equal(t, http.StatusFound, w.Code)
+				assert.Equal(t, tt.path, w.Header().Get("Location"))
+			})
+		}
+	})
+
+	t.Run("check redirect external method", func(t *testing.T) {
+		tests := []struct {
+			name         string
+			url          string
+			allowedHosts []string
+			wantErr      bool
+		}{
+			{
+				name:         "allowed host redirects",
+				url:          "https://api.example.com/callback",
+				allowedHosts: []string{"api.example.com"},
+			},
+			{
+				name:         "host not in allowlist",
+				url:          "https://evil.example.com/steal",
+				allowedHosts: []string{"api.example.com"},
+				wantErr:      true,
+			},
+			{
+				name:         "empty allowlist rejected",
+				url:          "https://api.example.com/callback",
+				allowedHosts: []string{},
+				wantErr:      true,
+			},
+			{
+				name:         "port is stripped when matching host",
+				url:          "https://api.example.com:8080/path",
+				allowedHosts: []string{"api.example.com"},
+			},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				req := httptest.NewRequest(http.MethodGet, "/", nil)
+				w := httptest.NewRecorder()
+				ctx := NewContext[any](w, req, nil)
+
+				err := ctx.RedirectExternal(tt.url, tt.allowedHosts)
+				if tt.wantErr {
+					assert.Error(t, err)
+					return
+				}
+				assert.Nil(t, err)
+				assert.Equal(t, http.StatusFound, w.Code)
+				assert.Equal(t, tt.url, w.Header().Get("Location"))
+			})
+		}
 	})
 
 	t.Run("Stream data w/o write header", func(t *testing.T) {

--- a/interfaces/icontext.go
+++ b/interfaces/icontext.go
@@ -15,7 +15,14 @@ type IContext[Bindings any] interface {
 	Text(text string) error
 	Bytes(data []byte) error
 	Json(data any) error
-	Redirect(url string) error
+	// Redirect sends a 302 response to a relative path.
+	// Returns an error if url is an absolute URL or protocol-relative URL.
+	// Use RedirectExternal for redirecting to external hosts.
+	Redirect(path string) error
+
+	// RedirectExternal sends a 302 response to an absolute URL.
+	// The host of url must appear in allowedHosts; returns an error otherwise.
+	RedirectExternal(url string, allowedHosts []string) error
 
 	// don't write header and status code
 	// so you can use for streaming response


### PR DESCRIPTION
## Summary

Fixes #62 (open redirect risk in `ctx.Redirect()`).

- **`ctx.Redirect(path)`** now only accepts relative paths. Absolute URLs (`https://...`) and protocol-relative URLs (`//...`) are rejected with an error, detected via `url.Parse` (consistent with `RedirectExternal`).
- **`ctx.RedirectExternal(url, allowedHosts)`** is a new method for redirecting to external hosts. The host of `url` is matched against the caller-supplied `allowedHosts` slice using `slices.Contains`.

## Usage example (with Bindings)

```go
type Bindings struct {
    AllowedRedirectHosts []string
}

app.Get("/oauth/callback", func(ctx MyContext) error {
    next := ctx.Req().QueryBy("next")
    return ctx.RedirectExternal(next, ctx.Env().AllowedRedirectHosts)
})
```

## Changes

| File | Change |
|---|---|
| `context.go` | `Redirect` validates path via `url.Parse`; `RedirectExternal` added with `slices.Contains` lookup |
| `interfaces/icontext.go` | `RedirectExternal(url string, allowedHosts []string) error` added to interface |
| `context_test.go` | Table-driven tests for both methods covering relative/absolute/allowlist/port cases |
| `README.md` | Safe Redirect section with Bindings-based allowlist example |

## Simplify cleanups applied

- Used `url.Parse` in `Redirect` instead of ad-hoc string heuristics — consistent with `RedirectExternal`
- Replaced manual host-matching loop with `slices.Contains` (already used in `router/helper.go`)
- Removed redundant `wantLocation` test field (always equal to `tt.url`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)