### PR TITLE
fix: stop timer to prevent leak when request completes before deadline

### DIFF
--- a/middlewares/timeout.go
+++ b/middlewares/timeout.go
@@ -27,11 +27,13 @@ func Timeout[Bindings any](limit time.Duration) interfaces.MiddlewareFunc[Bindin
 			result = next(ctx)
 		}()
 
+		timer := time.NewTimer(limit)
+		defer timer.Stop()
+
 		select {
 		case <-done:
 			return result
-		// this loaded
-		case <-time.After(limit):
+		case <-timer.C:
 			return constants.ErrRequestTimeout
 		}
 	}

--- a/middlewares/timeout_test.go
+++ b/middlewares/timeout_test.go
@@ -59,4 +59,24 @@ func TestTimeout(t *testing.T) {
 
 		assert.Error(t, err)
 	})
+
+	t.Run("timer is stopped when request completes before deadline", func(t *testing.T) {
+		// Run many back-to-back fast requests with a long timeout.
+		// If time.After leaks, each call leaves a live timer in the heap
+		// until the deadline expires. With time.NewTimer + Stop(), timers
+		// are cancelled immediately on the done path.
+		timeout := 30 * time.Second
+		mw := middlewares.Timeout[any](timeout)
+
+		for i := 0; i < 100; i++ {
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			rec := httptest.NewRecorder()
+			ctx := takibi.NewContext[any](rec, req, nil)
+
+			err := mw(ctx, func(c interfaces.IContext[any]) error {
+				return nil
+			})
+			assert.Nil(t, err)
+		}
+	})
 }


### PR DESCRIPTION
## Summary

Fixes #68.

- Replace `time.After(limit)` with `time.NewTimer(limit)` + `defer timer.Stop()` in `middlewares/timeout.go`
- When a request finishes before the deadline (`<-done` fires), `timer.Stop()` cancels the pending timer immediately, preventing it from sitting in the runtime timer heap until expiry

## Changes

- `middlewares/timeout.go`: use `time.NewTimer` + `defer timer.Stop()` instead of `time.After`
- `middlewares/timeout_test.go`: add test case that runs 100 fast requests with a 30s timeout, verifying correct behavior on the fast path

## Test plan

- [ ] `go test ./middlewares/... -run TestTimeout -v` — all four subtests pass
- [ ] `go test ./...` — full suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)