### PR TITLE
fix: default error handler no longer leaks raw error messages to clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,17 @@ func main() {
 }
 ```
 
+## Error Handling
+
+By default, takibi responds with a generic `"Internal Server Error"` message for unhandled errors — raw error details are never exposed to clients. Use `OnError` to customize the behavior:
+
+```go
+app.OnError(func(ctx interfaces.IContext[Bindings], err error) error {
+    // log err internally if needed
+    return ctx.Status(http.StatusInternalServerError).Text("something went wrong")
+})
+```
+
 ## Document
 
 docs link

--- a/error_handler_test.go
+++ b/error_handler_test.go
@@ -24,7 +24,7 @@ func TestDefaultErrorHandler(t *testing.T) {
 	app.ServeHTTP(w, r)
 
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
-	assert.Equal(t, "something went wrong", w.Body.String())
+	assert.Equal(t, "Internal Server Error", w.Body.String())
 }
 
 func TestCustomErrorHandler(t *testing.T) {

--- a/takibi_native.go
+++ b/takibi_native.go
@@ -45,7 +45,7 @@ func New[Bindings any](bindings *Bindings) interfaces.ITakibi[Bindings] {
 		env:    bindings,
 		router: router.New[Bindings](),
 		errorHandler: func(ctx interfaces.IContext[Bindings], err error) error {
-			return ctx.Status(http.StatusInternalServerError).Text(err.Error())
+			return ctx.Status(http.StatusInternalServerError).Text("Internal Server Error")
 		},
 		blowErrorHandler: func(c interfaces.IContext[Bindings], err error) {
 			fmt.Println(err.Error())


### PR DESCRIPTION
## Summary

- `takibi_native.go`: default `errorHandler` now returns `"Internal Server Error"` instead of `err.Error()`, preventing internal error details from being exposed to clients (OWASP A09 — Information Disclosure)
- `error_handler_test.go`: corrected assertion to match the new safe default
- `README.md`: added Error Handling section documenting the secure default and `OnError` override pattern

## Test plan

- [ ] `go test ./...` passes
- [ ] `TestDefaultErrorHandler` verifies the response body is `"Internal Server Error"` (not the raw error)
- [ ] `TestCustomErrorHandler` verifies custom handlers still work as expected

closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)