### PR TITLE
fix: add nil response guard to Redirect, RedirectExternal, and Render

### DIFF
--- a/context.go
+++ b/context.go
@@ -86,8 +86,8 @@ func (c *context[Bindings]) Stream(data []byte) error {
 }
 
 func (c *context[Bindings]) Json(data any) error {
-	if c.request.Raw() == nil || c.response == nil {
-		return fmt.Errorf("request or response is nil")
+	if err := c.checkResponse(); err != nil {
+		return err
 	}
 	contentType := c.request.Raw().Header.Get("Content-Type")
 	if !strings.Contains(contentType, "application/json") {

--- a/context.go
+++ b/context.go
@@ -50,9 +50,16 @@ func (c *context[Bindings]) Status(code int) interfaces.IContext[Bindings] {
 	return c
 }
 
-func (c *context[Bindings]) Text(text string) error {
+func (c *context[Bindings]) checkResponse() error {
 	if c.response == nil {
 		return fmt.Errorf("response is nil")
+	}
+	return nil
+}
+
+func (c *context[Bindings]) Text(text string) error {
+	if err := c.checkResponse(); err != nil {
+		return err
 	}
 	c.response.Header().Set("Content-Type", "text/plain")
 	c.response.WriteHeader(c.statusCode)
@@ -61,8 +68,8 @@ func (c *context[Bindings]) Text(text string) error {
 }
 
 func (c *context[Bindings]) Bytes(data []byte) error {
-	if c.response == nil {
-		return fmt.Errorf("response is nil")
+	if err := c.checkResponse(); err != nil {
+		return err
 	}
 	c.response.Header().Set("Content-Type", "application/octet-stream")
 	c.response.WriteHeader(c.statusCode)
@@ -71,10 +78,9 @@ func (c *context[Bindings]) Bytes(data []byte) error {
 }
 
 func (c *context[Bindings]) Stream(data []byte) error {
-	if c.response == nil {
-		return fmt.Errorf("response is nil")
+	if err := c.checkResponse(); err != nil {
+		return err
 	}
-
 	_, err := c.response.Write(data)
 	return err
 }
@@ -94,8 +100,8 @@ func (c *context[Bindings]) Json(data any) error {
 }
 
 func (c *context[Bindings]) Redirect(path string) error {
-	if c.response == nil {
-		return fmt.Errorf("response is nil")
+	if err := c.checkResponse(); err != nil {
+		return err
 	}
 	parsed, err := url.Parse(path)
 	if err == nil && parsed.Host != "" {
@@ -106,8 +112,8 @@ func (c *context[Bindings]) Redirect(path string) error {
 }
 
 func (c *context[Bindings]) RedirectExternal(rawURL string, allowedHosts []string) error {
-	if c.response == nil {
-		return fmt.Errorf("response is nil")
+	if err := c.checkResponse(); err != nil {
+		return err
 	}
 	if len(allowedHosts) == 0 {
 		return fmt.Errorf("redirect: allowedHosts must not be empty")
@@ -124,8 +130,8 @@ func (c *context[Bindings]) RedirectExternal(rawURL string, allowedHosts []strin
 }
 
 func (c *context[Bindings]) Render(config *interfaces.RenderConfig) error {
-	if c.response == nil {
-		return fmt.Errorf("response is nil")
+	if err := c.checkResponse(); err != nil {
+		return err
 	}
 	if config == nil {
 		return fmt.Errorf("config is nil")

--- a/context.go
+++ b/context.go
@@ -94,6 +94,9 @@ func (c *context[Bindings]) Json(data any) error {
 }
 
 func (c *context[Bindings]) Redirect(path string) error {
+	if c.response == nil {
+		return fmt.Errorf("response is nil")
+	}
 	parsed, err := url.Parse(path)
 	if err == nil && parsed.Host != "" {
 		return fmt.Errorf("redirect: absolute URLs are not allowed, use RedirectExternal")
@@ -103,6 +106,9 @@ func (c *context[Bindings]) Redirect(path string) error {
 }
 
 func (c *context[Bindings]) RedirectExternal(rawURL string, allowedHosts []string) error {
+	if c.response == nil {
+		return fmt.Errorf("response is nil")
+	}
 	if len(allowedHosts) == 0 {
 		return fmt.Errorf("redirect: allowedHosts must not be empty")
 	}
@@ -118,6 +124,9 @@ func (c *context[Bindings]) RedirectExternal(rawURL string, allowedHosts []strin
 }
 
 func (c *context[Bindings]) Render(config *interfaces.RenderConfig) error {
+	if c.response == nil {
+		return fmt.Errorf("response is nil")
+	}
 	if config == nil {
 		return fmt.Errorf("config is nil")
 	}

--- a/context_test.go
+++ b/context_test.go
@@ -117,6 +117,15 @@ func TestContext_Response(t *testing.T) {
 			assert.Error(t, err)
 			assert.Equal(t, "content-type must be application/json", err.Error())
 		})
+
+		t.Run("returns error when response is nil", func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			ctx := NewContext[any](nil, req, nil)
+
+			err := ctx.Json(map[string]string{"msg": "hello"})
+			assert.Error(t, err)
+			assert.Equal(t, "response is nil", err.Error())
+		})
 	})
 
 	t.Run("check status method", func(t *testing.T) {

--- a/context_test.go
+++ b/context_test.go
@@ -157,6 +157,15 @@ func TestContext_Response(t *testing.T) {
 				assert.Equal(t, tt.path, w.Header().Get("Location"))
 			})
 		}
+
+		t.Run("returns error when response is nil", func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			ctx := NewContext[any](nil, req, nil)
+
+			err := ctx.Redirect("/safe")
+			assert.Error(t, err)
+			assert.Equal(t, "response is nil", err.Error())
+		})
 	})
 
 	t.Run("check redirect external method", func(t *testing.T) {
@@ -205,6 +214,15 @@ func TestContext_Response(t *testing.T) {
 				assert.Equal(t, tt.url, w.Header().Get("Location"))
 			})
 		}
+
+		t.Run("returns error when response is nil", func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			ctx := NewContext[any](nil, req, nil)
+
+			err := ctx.RedirectExternal("https://api.example.com/cb", []string{"api.example.com"})
+			assert.Error(t, err)
+			assert.Equal(t, "response is nil", err.Error())
+		})
 	})
 
 	t.Run("Stream data w/o write header", func(t *testing.T) {
@@ -253,6 +271,19 @@ func TestContext_Response(t *testing.T) {
 			err := ctx.Render(nil)
 			assert.Error(t, err)
 			assert.Equal(t, "config is nil", err.Error())
+		})
+
+		t.Run("returns error when response is nil", func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			ctx := NewContext[any](nil, req, nil)
+
+			component := templ.ComponentFunc(func(ctx stdContext.Context, w io.Writer) error {
+				_, err := w.Write([]byte("Hello"))
+				return err
+			})
+			err := ctx.Render(&interfaces.RenderConfig{Component: component})
+			assert.Error(t, err)
+			assert.Equal(t, "response is nil", err.Error())
 		})
 	})
 }


### PR DESCRIPTION
## Summary

- `Redirect()`, `RedirectExternal()`, and `Render()` were missing nil checks on `c.response`
- `Blow()` tasks create a context with `nil` ResponseWriter, so calling any of these from a background task caused a nil pointer dereference panic
- Added early-return guards (matching the existing pattern in `Text()`, `Bytes()`, `Stream()`) that return `"response is nil"` instead of panicking

## Test plan

- [ ] `TestContext_Response/check_redirect_method/returns_error_when_response_is_nil` — confirms `Redirect()` returns error, not panic
- [ ] `TestContext_Response/check_redirect_external_method/returns_error_when_response_is_nil` — confirms `RedirectExternal()` returns error, not panic
- [ ] `TestContext_Response/render_component/returns_error_when_response_is_nil` — confirms `Render()` returns error, not panic
- [ ] All existing tests pass (`go test ./...`)

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)