### PR TITLE
fix(docs): fix shell/jsonc code blocks losing newlines

### DIFF
--- a/docs-tool/main.go
+++ b/docs-tool/main.go
@@ -16,6 +16,19 @@ import (
 
 var wsSpanRe = regexp.MustCompile(`<span class="w">([^<]*)</span>`)
 
+const labelStyle = `position:absolute;top:10px;right:14px;font-size:11px;color:#475569;font-family:sans-serif;text-transform:uppercase;letter-spacing:0.05em;`
+
+func detectLang(baseName string) (lexerName, label string) {
+	switch {
+	case strings.HasSuffix(baseName, "sh"):
+		return "bash", "shell"
+	case strings.HasSuffix(baseName, "jsonc"):
+		return "json", "jsonc"
+	default:
+		return "go", ""
+	}
+}
+
 func main() {
 	if len(os.Args) < 2 {
 		fmt.Println("使用方法: go run main.go <入力ファイルパス> [出力ファイルパス]")
@@ -49,7 +62,10 @@ func main() {
 		os.Exit(1)
 	}
 
-	lexer := lexers.Get("go")
+	baseName := strings.TrimSuffix(filepath.Base(inputFile), filepath.Ext(inputFile))
+	lexerName, label := detectLang(baseName)
+
+	lexer := lexers.Get(lexerName)
 	if lexer == nil {
 		lexer = lexers.Fallback
 	}
@@ -88,15 +104,21 @@ func main() {
 	htmlStr = strings.TrimRight(htmlStr, "\n")
 
 	packageName := filepath.Base(filepath.Dir(outputFile))
-	baseName := strings.TrimSuffix(filepath.Base(outputFile), filepath.Ext(outputFile))
-	funcName := strings.ToUpper(baseName[:1]) + baseName[1:]
+	outBase := strings.TrimSuffix(filepath.Base(outputFile), filepath.Ext(outputFile))
+	funcName := strings.ToUpper(outBase[:1]) + outBase[1:]
 
-	finalContent := fmt.Sprintf(
-		"package %s\n\ntempl %s() {\n\t@templ.Raw(\n\t\t`\n\t\t\t<pre class=\"chroma\"><code>%s</code></pre>\n\t\t`,\n\t)\n}\n",
-		packageName,
-		funcName,
-		htmlStr,
-	)
+	var finalContent string
+	if label != "" {
+		finalContent = fmt.Sprintf(
+			"package %s\n\ntempl %s() {\n\t@templ.Raw(\n\t\t`\n\t\t\t<pre class=\"chroma\"><span style=\"%s\">%s</span><code>%s</code></pre>\n\t\t`,\n\t)\n}\n",
+			packageName, funcName, labelStyle, label, htmlStr,
+		)
+	} else {
+		finalContent = fmt.Sprintf(
+			"package %s\n\ntempl %s() {\n\t@templ.Raw(\n\t\t`\n\t\t\t<pre class=\"chroma\"><code>%s</code></pre>\n\t\t`,\n\t)\n}\n",
+			packageName, funcName, htmlStr,
+		)
+	}
 
 	err = os.MkdirAll(filepath.Dir(outputFile), os.ModePerm)
 	if err != nil {

--- a/docs/templates/code/cloudflareworkercreateappssh.templ
+++ b/docs/templates/code/cloudflareworkercreateappssh.templ
@@ -1,0 +1,9 @@
+package code
+
+templ Cloudflareworkercreateappssh() {
+	@templ.Raw(
+		`
+			<pre class="chroma"><span style="position:absolute;top:10px;right:14px;font-size:11px;color:#475569;font-family:sans-serif;text-transform:uppercase;letter-spacing:0.05em;">shell</span><code>npm create cloudflare@latest -- --template github.com/poteto0/takibi/_templates/cloudflare-worker</code></pre>
+		`,
+	)
+}

--- a/docs/templates/code/cloudflareworkerdevsh.templ
+++ b/docs/templates/code/cloudflareworkerdevsh.templ
@@ -1,0 +1,11 @@
+package code
+
+templ Cloudflareworkerdevsh() {
+	@templ.Raw(
+		`
+			<pre class="chroma"><span style="position:absolute;top:10px;right:14px;font-size:11px;color:#475569;font-family:sans-serif;text-transform:uppercase;letter-spacing:0.05em;">shell</span><code>pnpm install
+pnpm run dev     <span class="c1"># local dev via wrangler</span>
+pnpm run deploy  <span class="c1"># deploy to Cloudflare</span></code></pre>
+		`,
+	)
+}

--- a/docs/templates/code/cloudflareworkerinitsh.templ
+++ b/docs/templates/code/cloudflareworkerinitsh.templ
@@ -1,0 +1,11 @@
+package code
+
+templ Cloudflareworkerinitsh() {
+	@templ.Raw(
+		`
+			<pre class="chroma"><span style="position:absolute;top:10px;right:14px;font-size:11px;color:#475569;font-family:sans-serif;text-transform:uppercase;letter-spacing:0.05em;">shell</span><code><span class="nb">cd</span> my-app
+go mod init
+go mod tidy</code></pre>
+		`,
+	)
+}

--- a/docs/templates/code/cloudflareworkerwranglerjsonc.templ
+++ b/docs/templates/code/cloudflareworkerwranglerjsonc.templ
@@ -1,0 +1,10 @@
+package code
+
+templ Cloudflareworkerwranglerjsonc() {
+	@templ.Raw(
+		`
+			<pre class="chroma"><span style="position:absolute;top:10px;right:14px;font-size:11px;color:#475569;font-family:sans-serif;text-transform:uppercase;letter-spacing:0.05em;">jsonc</span><code><span class="s2">&#34;kv_namespaces&#34;</span><span class="err">:</span> <span class="p">[</span><span class="p">&#123;</span> <span class="nt">&#34;binding&#34;</span><span class="p">:</span> <span class="s2">&#34;MyKV&#34;</span><span class="p">,</span> <span class="nt">&#34;id&#34;</span><span class="p">:</span> <span class="s2">&#34;&lt;KV_NAMESPACE_ID&gt;&#34;</span> <span class="p">&#125;</span><span class="p">]</span><span class="err">,</span>
+<span class="s2">&#34;vars&#34;</span><span class="err">:</span> <span class="p">&#123;</span> <span class="nt">&#34;Secret&#34;</span><span class="p">:</span> <span class="s2">&#34;my-secret-value&#34;</span> <span class="p">&#125;</span></code></pre>
+		`,
+	)
+}

--- a/docs/templates/code/gettingstartedsh.templ
+++ b/docs/templates/code/gettingstartedsh.templ
@@ -1,0 +1,11 @@
+package code
+
+templ Gettingstartedsh() {
+	@templ.Raw(
+		`
+			<pre class="chroma"><span style="position:absolute;top:10px;right:14px;font-size:11px;color:#475569;font-family:sans-serif;text-transform:uppercase;letter-spacing:0.05em;">shell</span><code>go run main.go
+curl http://localhost:8000/hello
+<span class="c1"># Hello, World!</span></code></pre>
+		`,
+	)
+}

--- a/docs/templates/pages/cloudflare_worker.templ
+++ b/docs/templates/pages/cloudflare_worker.templ
@@ -42,39 +42,16 @@ templ CloudflareWorker() {
 	</ul>
 	<p style="margin-top:12px;">No code changes are needed between the two environments.</p>
 	<h2>Create Apps</h2>
-	<pre>
-		<code>
-			npm create cloudflare@latest -- --template github.com/poteto0/takibi/_templates/cloudflare-worker
-		</code>
-	</pre>
+	@code.Cloudflareworkercreateappssh()
 	<h3>Initialize Project</h3>
-	<pre>
-		<code>
-			cd my-app
-			go mod init
-			go mod tidy
-		</code>
-	</pre>
+	@code.Cloudflareworkerinitsh()
 	<h3>Develop &amp; Deploy</h3>
-	<pre>
-		<span class={ styles.PreLabel() }>shell</span>
-		<code>
-			pnpm install
-			pnpm run dev     { "#" } local dev via wrangler
-			pnpm run deploy  { "#" } deploy to Cloudflare
-		</code>
-	</pre>
+	@code.Cloudflareworkerdevsh()
 	<h2>Application Code</h2>
 	@code.Cloudflareworkergo()
 	<h2>Workers Bindings Like Hono</h2>
 	<p>Add Cloudflare environment bindings (KV, secrets, etc.) to your <code>Bindings</code> struct for type-safe access:</p>
 	@code.Cloudflareworkerbindingsgo()
 	<p>Declare the same bindings in <code>wrangler.jsonc</code>:</p>
-	<pre>
-		<span class={ styles.PreLabel() }>jsonc</span>
-		<code>
-			&#34;kv_namespaces&#34;: [&#123; &#34;binding&#34;: &#34;MyKV&#34;, &#34;id&#34;: &#34;&lt;KV_NAMESPACE_ID&gt;&#34; &#125;],
-			&#34;vars&#34;: &#123; &#34;Secret&#34;: &#34;my-secret-value&#34; &#125;
-		</code>
-	</pre>
+	@code.Cloudflareworkerwranglerjsonc()
 }

--- a/docs/templates/pages/getting_started.templ
+++ b/docs/templates/pages/getting_started.templ
@@ -12,14 +12,7 @@ templ GettingStarted() {
 	<p>Create an app, register routes, and start the server:</p>
 	@code.Gettingstartedgo()
 	<h2>Run It</h2>
-	<pre>
-		<span class={ styles.PreLabel() }>shell</span>
-		<code>
-			go run main.go
-			curl http://localhost:8000/hello
-			# Hello, World!
-		</code>
-	</pre>
+	@code.Gettingstartedsh()
 	<h2>Next Steps</h2>
 	<p>Explore the core concepts and features:</p>
 	<ul style="list-style:none;display:flex;flex-direction:column;gap:8px;margin-top:8px;">


### PR DESCRIPTION
## Summary

- templ normalizes whitespace in HTML element text nodes, stripping newlines from multi-line `<code>` content inside `<pre>` — all lines were joined with spaces
- Extracted all shell and jsonc code blocks from page templates into `code/` components using `@templ.Raw()`, matching the pattern already used for Go code blocks
- Updated `docs-tool/main.go` to auto-detect language from filename suffix (`sh` → bash, `jsonc` → json) and embed an inline-styled language label span

## Changes

- `docs-tool/main.go`: add `detectLang()`, generate label span with inline styles for non-Go languages
- New code components: `gettingstartedsh`, `cloudflareworkercreateappssh`, `cloudflareworkerinitsh`, `cloudflareworkerdevsh`, `cloudflareworkerwranglerjsonc`
- `getting_started.templ`, `cloudflare_worker.templ`: replace inline `<pre>/<code>` blocks with `@code.*()` calls

## Test plan

- [ ] Run `just gen` and confirm `go build ./...` passes in `docs/`
- [ ] Visually verify "Run It" (getting started), "Initialize Project", "Develop & Deploy", and wrangler.jsonc blocks each render on separate lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)