### PR TITLE
ci(docs): auto-deploy docs to Cloudflare Workers on push to main

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -6,6 +6,11 @@ on:
       - main
     paths:
       - 'docs/**'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
 
 env:
   GO_VERSION: "1.26.1"
@@ -13,7 +18,7 @@ env:
   JUST_VERSION: "1.45.0"
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -41,7 +46,49 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
+          cache: 'pnpm'
+          cache-dependency-path: 'docs/pnpm-lock.yaml'
+
+      - name: Install dependencies
+        working-directory: docs
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        working-directory: docs
+        run: pnpm run build
+
+  deploy:
+    needs: build
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+          cache-dependency-path: docs/go.sum
+
+      - name: Setup templ
+        uses: a-h/setup-templ@v0
+        with:
+          version: ${{ env.TEMPL_VERSION }}
+
+      - name: Setup just
+        uses: extractions/setup-just@v4
+        with:
+          just-version: ${{ env.JUST_VERSION }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
           cache: 'pnpm'
           cache-dependency-path: 'docs/pnpm-lock.yaml'
 

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,61 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+
+env:
+  GO_VERSION: "1.26.1"
+  TEMPL_VERSION: "v0.3.1020"
+  JUST_VERSION: "1.45.0"
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+          cache-dependency-path: docs/go.sum
+
+      - name: Setup templ
+        uses: a-h/setup-templ@v0
+        with:
+          version: ${{ env.TEMPL_VERSION }}
+
+      - name: Setup just
+        uses: extractions/setup-just@v4
+        with:
+          just-version: ${{ env.JUST_VERSION }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+          cache-dependency-path: 'docs/pnpm-lock.yaml'
+
+      - name: Install dependencies
+        working-directory: docs
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        working-directory: docs
+        run: pnpm run build
+
+      - name: Deploy to Cloudflare Workers
+        working-directory: docs
+        run: pnpm run deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/deploy-docs.yml` that deploys the docs Cloudflare Worker automatically on every push to `main` that touches `docs/**`
- Build pipeline: `templ generate` → Go→WASM compile → `wrangler deploy`
- Uses `a-h/setup-templ@v0` (pre-built binary, cached) instead of `go install` for faster CI

## Required GitHub Secrets

Set these in **Settings → Secrets and variables → Actions** before this workflow will succeed:

| Secret | Where to get it |
|--------|----------------|
| `CLOUDFLARE_API_TOKEN` | Cloudflare dashboard → My Profile → API Tokens → Create Token with **Workers Scripts: Edit** permission |
| `CLOUDFLARE_ACCOUNT_ID` | Cloudflare dashboard → right sidebar on the Workers & Pages overview page |

## How it works

1. Triggered on push to `main` only when `docs/**` files change
2. Sets up Go (`1.26.1`), templ (`v0.3.1020`), just (`1.45.0`), pnpm (`11`, auto-resolved from `packageManager` in `package.json`), and Node.js 22
3. `pnpm run build` → calls `docs/scripts/build.sh` which runs `just gen` (templ generate), compiles Go to WASM, and assembles `build/`
4. `pnpm run deploy` → calls `wrangler deploy` using `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID`

🤖 Generated with [Claude Code](https://claude.com/claude-code)