### PR TITLE
fix(factory): return ErrParamMissing for missing params instead of silent zero value

### DIFF
--- a/constants/errors.go
+++ b/constants/errors.go
@@ -14,6 +14,10 @@ var (
 	ErrInvalidPath = errors.New(
 		"invalid path",
 	)
+
+	ErrParamMissing = errors.New(
+		"parameter is missing",
+	)
 )
 
 var (

--- a/factory/factory.go
+++ b/factory/factory.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/poteto0/takibi/constants"
 	"github.com/poteto0/takibi/interfaces"
 )
 
@@ -37,7 +38,9 @@ func QueryBy[T any](c RequestGetter, key string) (T, error) {
 func convert[T any](s string) (T, error) {
 	var result T
 	if s == "" {
-		return result, nil // Return zero value if empty? Or error? Usually zero value is safer but maybe ambiguous.
+		// A missing/empty param must not silently become a zero value:
+		// callers checking only err would otherwise treat e.g. id=0 as valid.
+		return result, constants.ErrParamMissing
 	}
 
 	switch any(result).(type) {

--- a/factory/factory_test.go
+++ b/factory/factory_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/poteto0/takibi"
+	"github.com/poteto0/takibi/constants"
 	"github.com/poteto0/takibi/interfaces"
 	"github.com/stretchr/testify/assert"
 )
@@ -42,13 +43,20 @@ func TestCreateMiddleware(t *testing.T) {
 func TestParamBy(t *testing.T) {
 	type Bindings struct{}
 
-	t.Run("0 value", func(t *testing.T) {
+	t.Run("missing param returns ErrParamMissing instead of zero value", func(t *testing.T) {
 		ctx := takibi.NewContext[Bindings](nil, nil, nil, nil)
 		ctx.SetParam(map[string]string{"id": ""})
 
 		val, err := ParamBy[int](ctx, "id")
-		assert.NoError(t, err)
-		assert.Equal(t, 0, val) // zero value for int
+		assert.ErrorIs(t, err, constants.ErrParamMissing)
+		assert.Equal(t, 0, val) // still zero value, but caller can detect the miss via err
+	})
+
+	t.Run("absent param key returns ErrParamMissing", func(t *testing.T) {
+		ctx := takibi.NewContext[Bindings](nil, nil, nil, nil)
+
+		_, err := ParamBy[string](ctx, "does-not-exist")
+		assert.ErrorIs(t, err, constants.ErrParamMissing)
 	})
 
 	t.Run("int", func(t *testing.T) {
@@ -168,5 +176,13 @@ func TestQueryBy(t *testing.T) {
 		val, err := QueryBy[bool](ctx, "flag")
 		assert.NoError(t, err)
 		assert.True(t, val)
+	})
+
+	t.Run("missing query returns ErrParamMissing", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		ctx := takibi.NewContext[Bindings](nil, req, nil, nil)
+
+		_, err := QueryBy[int](ctx, "page")
+		assert.ErrorIs(t, err, constants.ErrParamMissing)
 	})
 }


### PR DESCRIPTION
## 概要

Closes #95

`factory.convert()` は param / query が空・欠落のとき、エラーなしで型のゼロ値を返していた。呼び出し側が `err` だけを見ていると `ParamBy[int]("userId") == 0` を有効な ID として扱ってしまい、IDOR / 認可バイパスや、bool フラグが silently `false` に化けるセキュリティリスクがあった（`convert` 内のコメント自身も曖昧さを認めていた）。

## 変更

- `constants.ErrParamMissing` を追加。
- `convert()` は空入力時に `constants.ErrParamMissing` を返す。
- `ParamBy[T]` / `QueryBy[T]` の **シグネチャは不変**（`(T, error)` のまま）。欠落は err で判別可能になった。

## 挙動の変更（破壊的注意）

| ケース | before | after |
|---|---|---|
| `ParamBy[int]` で param 空/欠落 | `(0, nil)` | `(0, ErrParamMissing)` |
| `QueryBy[int]` で query 欠落 | `(0, nil)` | `(0, ErrParamMissing)` |

オプショナルなパラメータを扱う既存コードは、欠落を許容する場合 `errors.Is(err, constants.ErrParamMissing)` を明示的にハンドリングしてください（secure by default）。

## テスト (TDD)

- 既存の「0 value」テストを `ErrParamMissing` を期待するよう更新。
- param キー欠落 / query 欠落のケースを追加。
- `go test ./...` 全パッケージ green。

## docs

`factory.ParamBy[T]` / `QueryBy[T]` は `/docs` に記載がないためドキュメント変更なし（`/docs` の `QueryBy` 参照は `ctx.Req().QueryBy()` の別 API）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)