### PR TITLE
perf(router): lazy alloc in Find hot path; subtree-only handler recompose

### DIFF
--- a/interfaces/inode.go
+++ b/interfaces/inode.go
@@ -4,6 +4,11 @@ type INode[Bindings any] interface {
 	Handler() HandlerFunc[Bindings]
 	ComposedHandler() HandlerFunc[Bindings]
 	Add(path string, handler HandlerFunc[Bindings]) (err error)
+	// Find locates the node for path. On a matched route, callers use
+	// n.ComposedHandler() (middlewares are already composed into it) and
+	// middlewares is nil. middlewares is only populated on the not-found or
+	// handler-less paths, where it holds the matched-prefix middlewares for a
+	// fallback handler. pathParams is nil when the path has no parameters.
 	Find(path string) (n INode[Bindings], middlewares []MiddlewareFunc[Bindings], pathParams map[string]string)
 
 	Linearize() []NodeUnit[Bindings]

--- a/interfaces/irouter.go
+++ b/interfaces/irouter.go
@@ -5,8 +5,13 @@ type IRouter[Bindings any] interface {
 	LinearizeTree() map[string][]NodeUnit[Bindings]
 
 	/*
-		find router by method &
-		find node by path
+		find router by method & find node by path.
+
+		On a matched route, middlewares is nil — use INode.ComposedHandler(),
+		which already has the middlewares composed in. middlewares is only
+		populated on the not-found / handler-less paths (the matched-prefix
+		middlewares for a fallback handler). pathParams is nil when the path
+		has no parameters.
 	*/
 	Find(method, path string) (INode[Bindings], []MiddlewareFunc[Bindings], map[string]string)
 

--- a/router/helper.go
+++ b/router/helper.go
@@ -7,6 +7,16 @@ import (
 	"github.com/poteto0/takibi/constants"
 )
 
+// nextSegment splits the leading path segment off rightPath. It returns the
+// segment and the remaining path, which is "" once the last segment is
+// reached. Callers loop while the remaining path is non-empty.
+func nextSegment(rightPath string) (segment, rest string) {
+	if id := strings.Index(rightPath, "/"); id >= 0 {
+		return rightPath[:id], rightPath[id+1:]
+	}
+	return rightPath, ""
+}
+
 func hasPathParamPrefix(path string) bool {
 	if len(path) == 0 {
 		return false

--- a/router/node.go
+++ b/router/node.go
@@ -48,12 +48,10 @@ func Compose[Bindings any](
 	return handler
 }
 
-func (n *node[Bindings]) rebuildComposedHandlers() {
-	n.walkAndCompose(nil)
-}
-
-// walkAndCompose is the recursive DFS worker for rebuildComposedHandlers.
-// accumulated holds middlewares collected from ancestor nodes.
+// walkAndCompose recomposes the subtree rooted at n.
+// accumulated holds middlewares collected from ancestor nodes (excluding n).
+// Callers pass the ancestor middlewares so only the affected subtree is
+// rebuilt, instead of re-composing the whole tree on every registration.
 func (n *node[Bindings]) walkAndCompose(accumulated []interfaces.MiddlewareFunc[Bindings]) {
 	full := make([]interfaces.MiddlewareFunc[Bindings], len(accumulated)+len(n.middlewares))
 	copy(full, accumulated)
@@ -93,21 +91,15 @@ func (
 	// if path is just / or empty after trim, it's root
 	if path == "/" || path == "" {
 		currentNode.middlewares = append(currentNode.middlewares, middleware...)
-		n.rebuildComposedHandlers()
+		currentNode.walkAndCompose(nil)
 		return nil
 	}
 
 	rightPath := path[1:]
-	param := ""
+	var accumulated []interfaces.MiddlewareFunc[Bindings]
 
 	for {
-		id := strings.Index(rightPath, "/")
-		if id < 0 {
-			param = rightPath
-		} else {
-			param = rightPath[:id]
-			rightPath = rightPath[(id + 1):]
-		}
+		param, rest := nextSegment(rightPath)
 
 		if child := currentNode.children[param]; child == nil {
 			if hasPathParamPrefix(param) {
@@ -117,15 +109,17 @@ func (
 			currentNode.children[param] = NewNode[Bindings]().(*node[Bindings])
 		}
 
+		accumulated = append(accumulated, currentNode.middlewares...)
 		currentNode = currentNode.children[param].(*node[Bindings])
 
-		if id < 0 {
+		if rest == "" {
 			break
 		}
+		rightPath = rest
 	}
 
 	currentNode.middlewares = append(currentNode.middlewares, middleware...)
-	n.rebuildComposedHandlers()
+	currentNode.walkAndCompose(accumulated)
 	return nil
 }
 
@@ -143,20 +137,14 @@ func (
 			return constants.ErrHandlerAlreadyExists
 		}
 		currentNode.handler = handler
-		n.rebuildComposedHandlers()
+		currentNode.walkAndCompose(nil)
 		return nil
 	}
 
-	param := ""
+	var accumulated []interfaces.MiddlewareFunc[Bindings]
 
 	for {
-		id := strings.Index(rightPath, "/")
-		if id < 0 {
-			param = rightPath
-		} else {
-			param = rightPath[:id]
-			rightPath = rightPath[(id + 1):]
-		}
+		param, rest := nextSegment(rightPath)
 
 		if child := currentNode.children[param]; child == nil {
 			if hasPathParamPrefix(param) {
@@ -166,11 +154,13 @@ func (
 			currentNode.children[param] = NewNode[Bindings]().(*node[Bindings])
 		}
 
+		accumulated = append(accumulated, currentNode.middlewares...)
 		currentNode = currentNode.children[param].(*node[Bindings])
 
-		if id < 0 {
+		if rest == "" {
 			break
 		}
+		rightPath = rest
 	}
 
 	if currentNode.handler != nil {
@@ -178,7 +168,7 @@ func (
 	}
 
 	currentNode.handler = handler
-	n.rebuildComposedHandlers()
+	currentNode.walkAndCompose(accumulated)
 	return nil
 }
 
@@ -193,32 +183,16 @@ func (
 ) {
 	currentNode := n
 	rightPath := path[1:]
-	param := ""
-	pathParams := map[string]string{}
-	var middlewares []interfaces.MiddlewareFunc[Bindings]
+	// pathParams and middlewares are allocated lazily: a matched static route
+	// (the hot path) uses the node's pre-composed handler and needs neither.
+	var pathParams map[string]string
 
-	// Collect root middlewares
-	middlewares = append(middlewares, currentNode.middlewares...)
-
-	if rightPath == "" {
-		return currentNode, middlewares, pathParams
-	}
-
-	for {
-		id := strings.Index(rightPath, "/")
-		if id < 0 {
-			param = rightPath
-		} else {
-			param = rightPath[:id]
-			rightPath = rightPath[(id + 1):]
-		}
+	for rightPath != "" {
+		var param string
+		param, rightPath = nextSegment(rightPath)
 
 		if child := currentNode.children[param]; child != nil {
 			currentNode = child.(*node[Bindings])
-			middlewares = append(middlewares, currentNode.middlewares...)
-			if id < 0 {
-				break
-			}
 			continue
 		}
 
@@ -226,20 +200,59 @@ func (
 		if chParam := currentNode.childParamKey; chParam != "" {
 			if chNode := currentNode.children[chParam]; chNode != nil {
 				currentNode = chNode.(*node[Bindings])
-				middlewares = append(middlewares, currentNode.middlewares...)
+				if pathParams == nil {
+					pathParams = map[string]string{}
+				}
 				pathParams[chParam[1:]] = param
+				continue
 			}
-		} else {
-			// not found
-			return nil, middlewares, pathParams
 		}
 
-		if id < 0 {
-			break
-		}
+		// not found: collect prefix middlewares for the caller's 404 handler.
+		return nil, n.collectMiddlewares(path), pathParams
 	}
 
-	return currentNode, middlewares, pathParams
+	if currentNode.handler == nil {
+		// Matched an intermediate node without a handler. The caller treats
+		// this like not-found, so it still needs the prefix middlewares.
+		return currentNode, n.collectMiddlewares(path), pathParams
+	}
+
+	return currentNode, nil, pathParams
+}
+
+// collectMiddlewares walks path and accumulates the middlewares along the
+// matched prefix, outermost (root) first. It is only used on the cold
+// not-found / handler-less paths, so its allocations never hit matched routes.
+func (n *node[Bindings]) collectMiddlewares(
+	path string,
+) []interfaces.MiddlewareFunc[Bindings] {
+	currentNode := n
+	middlewares := append(
+		[]interfaces.MiddlewareFunc[Bindings]{},
+		currentNode.middlewares...,
+	)
+	rightPath := path[1:]
+
+	for rightPath != "" {
+		var param string
+		param, rightPath = nextSegment(rightPath)
+
+		next := currentNode.children[param]
+		if next == nil {
+			if chParam := currentNode.childParamKey; chParam != "" {
+				next = currentNode.children[chParam]
+			}
+		}
+		if next == nil {
+			break
+		}
+
+		currentNode = next.(*node[Bindings])
+		middlewares = append(middlewares, currentNode.middlewares...)
+	}
+
+	return middlewares
 }
 
 func (

--- a/router/node_test.go
+++ b/router/node_test.go
@@ -90,7 +90,7 @@ func TestNode_AddAndFind(t *testing.T) {
 			name:              "root",
 			path:              "/",
 			isNode:            true,
-			expectedPathParam: map[string]string{},
+			expectedPathParam: nil,
 		},
 		{
 			name:   "foo",
@@ -112,7 +112,7 @@ func TestNode_AddAndFind(t *testing.T) {
 			name:              "not found",
 			path:              "/not-found",
 			isNode:            false,
-			expectedPathParam: map[string]string{},
+			expectedPathParam: nil,
 		},
 	}
 
@@ -126,6 +126,36 @@ func TestNode_AddAndFind(t *testing.T) {
 			assert.Equal(t, test.isNode, n != nil)
 		})
 	}
+}
+
+func TestNode_Find_LazyAllocation(t *testing.T) {
+	t.Run("matched static route returns nil middlewares and pathParams", func(t *testing.T) {
+		n := NewNode[any]()
+		err := n.AddMiddleware("/", func(c interfaces.IContext[any], next interfaces.HandlerFunc[any]) error { return nil })
+		assert.Nil(t, err)
+		err = n.Add("/users", func(ctx interfaces.IContext[any]) error { return nil })
+		assert.Nil(t, err)
+
+		// The hot path: a matched route uses the pre-composed handler, so
+		// Find allocates neither the middlewares slice nor the pathParams map.
+		found, middlewares, pathParams := n.Find("/users")
+		assert.NotNil(t, found)
+		assert.NotNil(t, found.ComposedHandler())
+		assert.Nil(t, middlewares)
+		assert.Nil(t, pathParams)
+	})
+
+	t.Run("not found returns prefix middlewares for the 404 handler", func(t *testing.T) {
+		n := NewNode[any]()
+		err := n.AddMiddleware("/", func(c interfaces.IContext[any], next interfaces.HandlerFunc[any]) error { return nil })
+		assert.Nil(t, err)
+		err = n.AddMiddleware("/api", func(c interfaces.IContext[any], next interfaces.HandlerFunc[any]) error { return nil })
+		assert.Nil(t, err)
+
+		found, middlewares, _ := n.Find("/api/missing")
+		assert.Nil(t, found)
+		assert.Len(t, middlewares, 2) // root + api
+	})
 }
 
 func TestNode_Middlewares(t *testing.T) {

--- a/router/registration_bench_test.go
+++ b/router/registration_bench_test.go
@@ -1,0 +1,30 @@
+package router
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/poteto0/takibi/interfaces"
+)
+
+func benchRegNopHandler(ctx interfaces.IContext[any]) error { return nil }
+
+// benchmarkRegister registers numRoutes distinct routes from scratch, exercising
+// the per-registration handler (re)composition. The old implementation
+// re-composed the entire tree on every Add (O(N^2)); the new one recomposes
+// only the inserted subtree (O(N) overall).
+func benchmarkRegister(b *testing.B, numRoutes int) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		tr := New[any]()
+		for j := 0; j < numRoutes; j++ {
+			_ = tr.Get("/route/"+strconv.Itoa(j), benchRegNopHandler)
+		}
+	}
+}
+
+func BenchmarkRegister_100(b *testing.B)  { benchmarkRegister(b, 100) }
+func BenchmarkRegister_500(b *testing.B)  { benchmarkRegister(b, 500) }
+func BenchmarkRegister_1000(b *testing.B) { benchmarkRegister(b, 1000) }
+func BenchmarkRegister_2000(b *testing.B) { benchmarkRegister(b, 2000) }


### PR DESCRIPTION
## 概要

closes #91

`router` のパフォーマンス改善2点。

### 1. `Find()` ホットパスの不要な確保を遅延化

リクエストごとに呼ばれる `Find()` が、マッチした静的ルートでは使われない `pathParams` map と `middlewares` slice を毎回確保していた。マッチ時は `n.ComposedHandler()`（middleware は compose 済み）を使うため、どちらも不要。

- `pathParams` は param ルートにマッチしたときだけ lazy 確保。
- middleware の収集は cold path 専用の `collectMiddlewares()` に分離し、not-found / handler 無しノードにマッチした場合のみ実行。

結果、高トラフィックな静的ルートの `Find()` は **アロケーションゼロ**（nil middlewares / nil pathParams）。

### 2. 登録ごとの全ツリー再 compose (O(N^2)) を解消

`Add` / `AddMiddleware` が毎回 `rebuildComposedHandlers()` でツリー全体を DFS 再 compose していた（ルート N 本で O(N^2)）。

- traversal 中に祖先 middleware を蓄積し、挿入ノードのサブツリーだけ `walkAndCompose(accumulated)` で再 compose。サブツリーサイズに比例。

### その他（`/simplify` 由来のクリーンアップ）

- 4箇所に重複していたパスセグメント分割を `nextSegment()` ヘルパに抽出。
- `Find` の nil-middlewares / nil-pathParams 契約を `interfaces` の doc コメントに明文化。

## テスト

- 既存テストの `pathParams` 期待値を lazy 化に合わせて更新（root / not-found は `nil`）。
- `TestNode_Find_LazyAllocation` を追加：マッチした静的ルートが nil middlewares / nil pathParams を返すこと、not-found が prefix middleware を返すことを検証。
- `go test ./...` 全パス。

🤖 Generated with [Claude Code](https://claude.com/claude-code)