### PR TITLE
security(cookie): enforce 32-byte minimum secret length for signed cookies

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,25 @@ app.Post("/upload", func(ctx MyContext) error {
 
 `Unmarshall` requires a JSON request body. The `Content-Type` is matched on its media type, so values carrying parameters such as `application/json; charset=utf-8` are accepted.
 
+## Signed Cookies
+
+`cookie.SetSignedCookie` and `cookie.GetSignedCookie` HMAC-sign cookie values using `gorilla/securecookie`. The `secret` must be **at least 32 bytes**; shorter secrets are rejected and the functions return `false`/`nil, false` immediately.
+
+```go
+import "github.com/poteto0/takibi/cookie"
+
+// secret must be >= 32 bytes
+secret := "my-32-byte-or-longer-secret-key!!"
+
+// set
+ok := cookie.SetSignedCookie[Bindings](ctx, "session", userID, secret, nil)
+
+// get (returns decoded value; false if missing, tampered, or wrong secret)
+c, ok := cookie.GetSignedCookie[Bindings](ctx, "session", secret, nil)
+```
+
+Use `constants.MinSignedCookieSecretLen` (32) as the documented minimum when generating secrets.
+
 ## Document
 
 docs link

--- a/constants/cookie.go
+++ b/constants/cookie.go
@@ -5,4 +5,8 @@ const (
 	CookieHostPrefix       = "__Host-"
 	CookieSecurePrefixMode = "secure"
 	CookieHostPrefixMode   = "host"
+
+	// MinSignedCookieSecretLen is the minimum required byte length for HMAC signing secrets.
+	// gorilla/securecookie recommends 32 or 64 bytes for the hash key.
+	MinSignedCookieSecretLen = 32
 )

--- a/cookie/cookie.go
+++ b/cookie/cookie.go
@@ -60,8 +60,20 @@ func GetCookie[T any](ctx interfaces.IContext[T], name string, opts *CookieOptio
 	return c, true
 }
 
+// newSignedCookieCodec returns a securecookie codec for the given secret, or
+// nil when the secret is shorter than MinSignedCookieSecretLen.
+func newSignedCookieCodec(secret string) *securecookie.SecureCookie {
+	if len(secret) < constants.MinSignedCookieSecretLen {
+		return nil
+	}
+	return securecookie.New([]byte(secret), nil)
+}
+
 func SetSignedCookie[T any](ctx interfaces.IContext[T], name, value, secret string, opts *CookieOptions) bool {
-	s := securecookie.New([]byte(secret), nil)
+	s := newSignedCookieCodec(secret)
+	if s == nil {
+		return false
+	}
 	encoded, err := s.Encode(name, value)
 	if err != nil {
 		return false
@@ -70,18 +82,20 @@ func SetSignedCookie[T any](ctx interfaces.IContext[T], name, value, secret stri
 }
 
 func GetSignedCookie[T any](ctx interfaces.IContext[T], name, secret string, opts *CookieOptions) (*http.Cookie, bool) {
+	s := newSignedCookieCodec(secret)
+	if s == nil {
+		return nil, false
+	}
 	c, ok := GetCookie(ctx, name, opts)
 	if !ok {
 		return nil, false
 	}
 
-	s := securecookie.New([]byte(secret), nil)
 	var value string
 	if err := s.Decode(name, c.Value, &value); err != nil {
 		return nil, false
 	}
 
-	// Return a copy with decoded value
 	decodedCookie := *c
 	decodedCookie.Value = value
 	return &decodedCookie, true

--- a/cookie/cookie_test.go
+++ b/cookie/cookie_test.go
@@ -290,4 +290,35 @@ func TestSignedCookie(t *testing.T) {
 		assert.False(t, ok)
 		assert.Nil(t, c)
 	})
+
+	t.Run("fail when secret is too short for SetSignedCookie", func(t *testing.T) {
+		// Arrange
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest("GET", "/", nil)
+		ctx := takibi.NewContext[any](w, r, nil, nil)
+		secret := "short"
+
+		// Act
+		ok := cookie.SetSignedCookie[any](ctx, "name", "takibi", secret, nil)
+
+		// Assert
+		assert.False(t, ok)
+		assert.Empty(t, w.Result().Cookies())
+	})
+
+	t.Run("fail when secret is too short for GetSignedCookie", func(t *testing.T) {
+		// Arrange
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest("GET", "/", nil)
+		ctx := takibi.NewContext[any](w, r, nil, nil)
+		secret := "short"
+		r.AddCookie(&http.Cookie{Name: "name", Value: "somevalue"})
+
+		// Act
+		c, ok := cookie.GetSignedCookie[any](ctx, "name", secret, nil)
+
+		// Assert
+		assert.False(t, ok)
+		assert.Nil(t, c)
+	})
 }


### PR DESCRIPTION
## Summary

- `SetSignedCookie` and `GetSignedCookie` now reject any `secret` shorter than 32 bytes (`constants.MinSignedCookieSecretLen`), returning `false`/`nil, false` immediately — closes #94
- Shared validation + codec construction extracted into a private `newSignedCookieCodec` helper to eliminate duplication
- README documents the minimum requirement and usage example

## Test plan

- [ ] `go test ./cookie/... -run TestSignedCookie -v` — all subtests pass including two new cases: "fail when secret is too short for SetSignedCookie" and "fail when secret is too short for GetSignedCookie"
- [ ] `go test ./...` — full suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)