### PR TITLE
feat(middlewares): add SecureHeaders middleware (closes #65)

### DIFF
--- a/middlewares/secure_headers.go
+++ b/middlewares/secure_headers.go
@@ -1,0 +1,40 @@
+package middlewares
+
+import "github.com/poteto0/takibi/interfaces"
+
+type SecureHeadersConfig struct {
+	XContentTypeOptions string
+	XFrameOptions       string
+	ReferrerPolicy      string
+}
+
+func DefaultSecureHeadersConfig() SecureHeadersConfig {
+	return SecureHeadersConfig{
+		XContentTypeOptions: "nosniff",
+		XFrameOptions:       "DENY",
+		ReferrerPolicy:      "strict-origin-when-cross-origin",
+	}
+}
+
+func SecureHeaders[Bindings any](config ...SecureHeadersConfig) interfaces.MiddlewareFunc[Bindings] {
+	cfg := DefaultSecureHeadersConfig()
+	if len(config) > 0 {
+		cfg = config[0]
+	}
+
+	return func(c interfaces.IContext[Bindings], next interfaces.HandlerFunc[Bindings]) error {
+		h := c.Response().Header()
+
+		if cfg.XContentTypeOptions != "" {
+			h.Set("X-Content-Type-Options", cfg.XContentTypeOptions)
+		}
+		if cfg.XFrameOptions != "" {
+			h.Set("X-Frame-Options", cfg.XFrameOptions)
+		}
+		if cfg.ReferrerPolicy != "" {
+			h.Set("Referrer-Policy", cfg.ReferrerPolicy)
+		}
+
+		return next(c)
+	}
+}

--- a/middlewares/secure_headers_test.go
+++ b/middlewares/secure_headers_test.go
@@ -1,0 +1,52 @@
+package middlewares_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/poteto0/takibi"
+	"github.com/poteto0/takibi/interfaces"
+	"github.com/poteto0/takibi/middlewares"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSecureHeaders(t *testing.T) {
+	run := func(mw interfaces.MiddlewareFunc[any]) (*httptest.ResponseRecorder, bool) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rec := httptest.NewRecorder()
+		ctx := takibi.NewContext[any](rec, req, nil, nil)
+		var nextCalled bool
+		_ = mw(ctx, func(c interfaces.IContext[any]) error {
+			nextCalled = true
+			return nil
+		})
+		return rec, nextCalled
+	}
+
+	t.Run("default config sets all security headers", func(t *testing.T) {
+		rec, _ := run(middlewares.SecureHeaders[any]())
+		assert.Equal(t, "nosniff", rec.Header().Get("X-Content-Type-Options"))
+		assert.Equal(t, "DENY", rec.Header().Get("X-Frame-Options"))
+		assert.Equal(t, "strict-origin-when-cross-origin", rec.Header().Get("Referrer-Policy"))
+	})
+
+	t.Run("custom config overrides X-Frame-Options", func(t *testing.T) {
+		rec, _ := run(middlewares.SecureHeaders[any](middlewares.SecureHeadersConfig{
+			XFrameOptions: "SAMEORIGIN",
+		}))
+		assert.Equal(t, "SAMEORIGIN", rec.Header().Get("X-Frame-Options"))
+	})
+
+	t.Run("empty X-Frame-Options skips the header", func(t *testing.T) {
+		rec, _ := run(middlewares.SecureHeaders[any](middlewares.SecureHeadersConfig{
+			XFrameOptions: "",
+		}))
+		assert.Empty(t, rec.Header().Get("X-Frame-Options"))
+	})
+
+	t.Run("calls next handler", func(t *testing.T) {
+		_, nextCalled := run(middlewares.SecureHeaders[any]())
+		assert.True(t, nextCalled)
+	})
+}


### PR DESCRIPTION
## Summary

- Adds `middlewares.SecureHeaders[Bindings]()` middleware that sets three HTTP security headers on every response
- `X-Content-Type-Options: nosniff` — prevents MIME-type sniffing / content-sniffing XSS
- `X-Frame-Options: DENY` — prevents clickjacking
- `Referrer-Policy: strict-origin-when-cross-origin` — limits referrer leakage
- Each header is individually opt-outable by setting the corresponding `SecureHeadersConfig` field to `""` — an empty string skips that header entirely
- Follows the existing `Config + DefaultConfig + Middleware` pattern established by `Cors`

## Usage

```go
// default secure headers
app.Use(middlewares.SecureHeaders[Bindings]())

// custom: allow framing from same origin, keep other defaults
app.Use(middlewares.SecureHeaders[Bindings](middlewares.SecureHeadersConfig{
    XContentTypeOptions: "nosniff",
    XFrameOptions:       "SAMEORIGIN",
    ReferrerPolicy:      "strict-origin-when-cross-origin",
}))
```

## Test plan

- [x] `go test ./middlewares/... -run TestSecureHeaders -v` — all 4 subtests pass
- [x] `go test ./...` — full suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)