### PR TITLE
feat(docs): add full API documentation

### DIFF
--- a/docs/main.go
+++ b/docs/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/a-h/templ"
 	"github.com/poteto0/takibi"
 	"github.com/poteto0/takibi-docs/templates/layouts"
 	"github.com/poteto0/takibi-docs/templates/pages"
@@ -11,6 +12,14 @@ type Bindings struct{}
 
 type MyContext = interfaces.IContext[Bindings]
 
+func docPage(title, active string, component templ.Component) func(ctx MyContext) error {
+	return func(ctx MyContext) error {
+		return ctx.Render(&interfaces.RenderConfig{
+			Component: layouts.Layout(title, active, component),
+		})
+	}
+}
+
 func main() {
 	app := takibi.New(&Bindings{})
 
@@ -18,53 +27,23 @@ func main() {
 		return ctx.Status(500).Text("internal-server-error")
 	})
 
-	app.Get("/", func(ctx MyContext) error {
-		return ctx.Render(&interfaces.RenderConfig{
-			Component: layouts.Layout("Home", "home", pages.Home()),
-		})
-	})
+	app.Get("/", docPage("Home", "home", pages.Home()))
+	app.Get("/getting-started", docPage("Getting Started", "getting-started", pages.GettingStarted()))
+	app.Get("/getting-started/cloudflare-workers", docPage("Cloudflare Workers", "cloudflare-workers", pages.CloudflareWorker()))
 
-	app.Get("/getting-started", func(ctx MyContext) error {
-		return ctx.Render(&interfaces.RenderConfig{
-			Component: layouts.Layout("Getting Started", "getting-started", pages.GettingStarted()),
-		})
-	})
+	app.Get("/docs/type-safe-context", docPage("Type-Safe Context", "type-safe-context", pages.TypeSafeContext()))
+	app.Get("/docs/routing", docPage("Routing", "routing", pages.Routing()))
+	app.Get("/docs/sub-routing", docPage("Sub-Routing", "sub-routing", pages.SubRouting()))
 
-	app.Get("/getting-started/cloudflare-workers", func(ctx MyContext) error {
-		return ctx.Render(&interfaces.RenderConfig{
-			Component: layouts.Layout("Cloudflare Workers", "cloudflare-workers", pages.CloudflareWorker()),
-		})
-	})
+	app.Get("/docs/middleware", docPage("Middleware", "middleware", pages.Middleware()))
+	app.Get("/docs/redirect", docPage("Redirect", "redirect", pages.Redirect()))
+	app.Get("/docs/error-handling", docPage("Error Handling", "error-handling", pages.ErrorHandling()))
+	app.Get("/docs/request-body", docPage("Request Body", "request-body", pages.RequestBody()))
+	app.Get("/docs/cookie", docPage("Cookie", "cookie", pages.Cookie()))
 
-	app.Get("/docs/type-safe-context", func(ctx MyContext) error {
-		return ctx.Render(&interfaces.RenderConfig{
-			Component: layouts.Layout("Type-Safe Context", "type-safe-context", pages.TypeSafeContext()),
-		})
-	})
-
-	app.Get("/docs/routing", func(ctx MyContext) error {
-		return ctx.Render(&interfaces.RenderConfig{
-			Component: layouts.Layout("Routing", "routing", pages.Routing()),
-		})
-	})
-
-	app.Get("/docs/redirect", func(ctx MyContext) error {
-		return ctx.Render(&interfaces.RenderConfig{
-			Component: layouts.Layout("Redirect", "redirect", pages.Redirect()),
-		})
-	})
-
-	app.Get("/docs/error-handling", func(ctx MyContext) error {
-		return ctx.Render(&interfaces.RenderConfig{
-			Component: layouts.Layout("Error Handling", "error-handling", pages.ErrorHandling()),
-		})
-	})
-
-	app.Get("/docs/request-body", func(ctx MyContext) error {
-		return ctx.Render(&interfaces.RenderConfig{
-			Component: layouts.Layout("Request Body", "request-body", pages.RequestBody()),
-		})
-	})
+	app.Get("/docs/factory", docPage("Factory Helpers", "factory", pages.Factory()))
+	app.Get("/docs/testing", docPage("Testing", "testing", pages.Testing()))
+	app.Get("/docs/blow", docPage("Background Tasks", "blow", pages.Blow()))
 
 	app.Fire("")
 }

--- a/docs/templates/code/blowschedulego.templ
+++ b/docs/templates/code/blowschedulego.templ
@@ -1,0 +1,16 @@
+package code
+
+templ Blowschedulego() {
+	@templ.Raw(
+		`
+			<pre class="chroma"><code><span class="c1">// cron schedule uses robfig/cron format (optionally with seconds)</span>
+<span class="nx">app</span><span class="p">.</span><span class="nf">Blow</span><span class="p">(</span><span class="nx">interfaces</span><span class="p">.</span><span class="nx">BlowTask</span><span class="p">[</span><span class="nx">Bindings</span><span class="p">]</span><span class="p">&#123;</span>
+	<span class="nx">BlowActionTag</span><span class="p">:</span>      <span class="s">&#34;schedule&#34;</span><span class="p">,</span>
+	<span class="nx">BlowActionSchedule</span><span class="p">:</span> <span class="s">&#34;0 * * * *&#34;</span><span class="p">,</span> <span class="c1">// every hour</span>
+	<span class="nx">BlowAction</span><span class="p">:</span> <span class="kd">func</span><span class="p">(</span><span class="nx">ctx</span> <span class="nx">interfaces</span><span class="p">.</span><span class="nx">IContext</span><span class="p">[</span><span class="nx">Bindings</span><span class="p">]</span><span class="p">)</span> <span class="kt">error</span> <span class="p">&#123;</span>
+		<span class="k">return</span> <span class="nx">ctx</span><span class="p">.</span><span class="nf">Env</span><span class="p">(</span><span class="p">)</span><span class="p">.</span><span class="nx">DB</span><span class="p">.</span><span class="nf">Cleanup</span><span class="p">(</span><span class="p">)</span>
+	<span class="p">&#125;</span><span class="p">,</span>
+<span class="p">&#125;</span><span class="p">)</span></code></pre>
+		`,
+	)
+}

--- a/docs/templates/code/blowtriggergo.templ
+++ b/docs/templates/code/blowtriggergo.templ
@@ -1,0 +1,26 @@
+package code
+
+templ Blowtriggergo() {
+	@templ.Raw(
+		`
+			<pre class="chroma"><code><span class="nx">app</span><span class="p">.</span><span class="nf">Blow</span><span class="p">(</span>
+	<span class="nx">interfaces</span><span class="p">.</span><span class="nx">BlowTask</span><span class="p">[</span><span class="nx">Bindings</span><span class="p">]</span><span class="p">&#123;</span>
+		<span class="nx">BlowActionTag</span><span class="p">:</span>     <span class="s">&#34;trigger&#34;</span><span class="p">,</span>
+		<span class="nx">BlowActionTrigger</span><span class="p">:</span> <span class="s">&#34;start&#34;</span><span class="p">,</span>
+		<span class="nx">BlowAction</span><span class="p">:</span> <span class="kd">func</span><span class="p">(</span><span class="nx">ctx</span> <span class="nx">interfaces</span><span class="p">.</span><span class="nx">IContext</span><span class="p">[</span><span class="nx">Bindings</span><span class="p">]</span><span class="p">)</span> <span class="kt">error</span> <span class="p">&#123;</span>
+			<span class="nx">fmt</span><span class="p">.</span><span class="nf">Println</span><span class="p">(</span><span class="s">&#34;server started — warming up caches&#34;</span><span class="p">)</span>
+			<span class="k">return</span> <span class="kc">nil</span>
+		<span class="p">&#125;</span><span class="p">,</span>
+	<span class="p">&#125;</span><span class="p">,</span>
+	<span class="nx">interfaces</span><span class="p">.</span><span class="nx">BlowTask</span><span class="p">[</span><span class="nx">Bindings</span><span class="p">]</span><span class="p">&#123;</span>
+		<span class="nx">BlowActionTag</span><span class="p">:</span>     <span class="s">&#34;trigger&#34;</span><span class="p">,</span>
+		<span class="nx">BlowActionTrigger</span><span class="p">:</span> <span class="s">&#34;stop&#34;</span><span class="p">,</span>
+		<span class="nx">BlowAction</span><span class="p">:</span> <span class="kd">func</span><span class="p">(</span><span class="nx">ctx</span> <span class="nx">interfaces</span><span class="p">.</span><span class="nx">IContext</span><span class="p">[</span><span class="nx">Bindings</span><span class="p">]</span><span class="p">)</span> <span class="kt">error</span> <span class="p">&#123;</span>
+			<span class="nx">fmt</span><span class="p">.</span><span class="nf">Println</span><span class="p">(</span><span class="s">&#34;server stopping — flushing state&#34;</span><span class="p">)</span>
+			<span class="k">return</span> <span class="kc">nil</span>
+		<span class="p">&#125;</span><span class="p">,</span>
+	<span class="p">&#125;</span><span class="p">,</span>
+<span class="p">)</span></code></pre>
+		`,
+	)
+}

--- a/docs/templates/code/campbasicgo.templ
+++ b/docs/templates/code/campbasicgo.templ
@@ -1,0 +1,24 @@
+package code
+
+templ Campbasicgo() {
+	@templ.Raw(
+		`
+			<pre class="chroma"><code><span class="kd">func</span> <span class="nf">TestGetUser</span><span class="p">(</span><span class="nx">t</span> <span class="o">*</span><span class="nx">testing</span><span class="p">.</span><span class="nx">T</span><span class="p">)</span> <span class="p">&#123;</span>
+	<span class="nx">app</span> <span class="o">:=</span> <span class="nx">takibi</span><span class="p">.</span><span class="nx">New</span><span class="p">[</span><span class="kt">any</span><span class="p">]</span><span class="p">(</span><span class="kc">nil</span><span class="p">)</span>
+	<span class="nx">app</span><span class="p">.</span><span class="nf">Get</span><span class="p">(</span><span class="s">&#34;/users/:id&#34;</span><span class="p">,</span> <span class="kd">func</span><span class="p">(</span><span class="nx">ctx</span> <span class="nx">interfaces</span><span class="p">.</span><span class="nx">IContext</span><span class="p">[</span><span class="kt">any</span><span class="p">]</span><span class="p">)</span> <span class="kt">error</span> <span class="p">&#123;</span>
+		<span class="nx">id</span> <span class="o">:=</span> <span class="nx">ctx</span><span class="p">.</span><span class="nf">ParamBy</span><span class="p">(</span><span class="s">&#34;id&#34;</span><span class="p">)</span>
+		<span class="k">return</span> <span class="nx">ctx</span><span class="p">.</span><span class="nf">Json</span><span class="p">(</span><span class="kd">map</span><span class="p">[</span><span class="kt">string</span><span class="p">]</span><span class="kt">string</span><span class="p">&#123;</span><span class="s">&#34;id&#34;</span><span class="p">:</span> <span class="nx">id</span><span class="p">&#125;</span><span class="p">)</span>
+	<span class="p">&#125;</span><span class="p">)</span>
+
+	<span class="nx">res</span> <span class="o">:=</span> <span class="nx">app</span><span class="p">.</span><span class="nf">Camp</span><span class="p">(</span><span class="s">&#34;GET&#34;</span><span class="p">,</span> <span class="s">&#34;/users/42&#34;</span><span class="p">)</span>
+	<span class="k">if</span> <span class="nx">res</span><span class="p">.</span><span class="nf">StatusCode</span><span class="p">(</span><span class="p">)</span> <span class="o">!=</span> <span class="mi">200</span> <span class="p">&#123;</span>
+		<span class="nx">t</span><span class="p">.</span><span class="nf">Fatalf</span><span class="p">(</span><span class="s">&#34;expected 200, got %d&#34;</span><span class="p">,</span> <span class="nx">res</span><span class="p">.</span><span class="nf">StatusCode</span><span class="p">(</span><span class="p">)</span><span class="p">)</span>
+	<span class="p">&#125;</span>
+
+	<span class="kd">var</span> <span class="nx">body</span> <span class="kd">map</span><span class="p">[</span><span class="kt">string</span><span class="p">]</span><span class="kt">string</span>
+	<span class="nx">res</span><span class="p">.</span><span class="nf">Unmarshall</span><span class="p">(</span><span class="o">&amp;</span><span class="nx">body</span><span class="p">)</span>
+	<span class="c1">// body[&#34;id&#34;] == &#34;42&#34;</span>
+<span class="p">&#125;</span></code></pre>
+		`,
+	)
+}

--- a/docs/templates/code/camppostgo.templ
+++ b/docs/templates/code/camppostgo.templ
@@ -1,0 +1,25 @@
+package code
+
+templ Camppostgo() {
+	@templ.Raw(
+		`
+			<pre class="chroma"><code><span class="kd">func</span> <span class="nf">TestCreateUser</span><span class="p">(</span><span class="nx">t</span> <span class="o">*</span><span class="nx">testing</span><span class="p">.</span><span class="nx">T</span><span class="p">)</span> <span class="p">&#123;</span>
+	<span class="nx">app</span> <span class="o">:=</span> <span class="nx">takibi</span><span class="p">.</span><span class="nx">New</span><span class="p">[</span><span class="kt">any</span><span class="p">]</span><span class="p">(</span><span class="kc">nil</span><span class="p">)</span>
+	<span class="nx">app</span><span class="p">.</span><span class="nf">Post</span><span class="p">(</span><span class="s">&#34;/users&#34;</span><span class="p">,</span> <span class="kd">func</span><span class="p">(</span><span class="nx">ctx</span> <span class="nx">interfaces</span><span class="p">.</span><span class="nx">IContext</span><span class="p">[</span><span class="kt">any</span><span class="p">]</span><span class="p">)</span> <span class="kt">error</span> <span class="p">&#123;</span>
+		<span class="kd">var</span> <span class="nx">req</span> <span class="kd">map</span><span class="p">[</span><span class="kt">string</span><span class="p">]</span><span class="kt">string</span>
+		<span class="nx">ctx</span><span class="p">.</span><span class="nf">Req</span><span class="p">(</span><span class="p">)</span><span class="p">.</span><span class="nf">Unmarshall</span><span class="p">(</span><span class="o">&amp;</span><span class="nx">req</span><span class="p">)</span>
+		<span class="k">return</span> <span class="nx">ctx</span><span class="p">.</span><span class="nf">Status</span><span class="p">(</span><span class="mi">201</span><span class="p">)</span><span class="p">.</span><span class="nf">Json</span><span class="p">(</span><span class="nx">req</span><span class="p">)</span>
+	<span class="p">&#125;</span><span class="p">)</span>
+
+	<span class="nx">res</span> <span class="o">:=</span> <span class="nx">app</span><span class="p">.</span><span class="nf">Camp</span><span class="p">(</span><span class="s">&#34;POST&#34;</span><span class="p">,</span> <span class="s">&#34;/users&#34;</span><span class="p">,</span>
+		<span class="nx">interfaces</span><span class="p">.</span><span class="nf">Header</span><span class="p">(</span><span class="s">&#34;Content-Type&#34;</span><span class="p">,</span> <span class="s">&#34;application/json&#34;</span><span class="p">)</span><span class="p">,</span>
+		<span class="nx">interfaces</span><span class="p">.</span><span class="nf">Body</span><span class="p">(</span><span class="kd">map</span><span class="p">[</span><span class="kt">string</span><span class="p">]</span><span class="kt">string</span><span class="p">&#123;</span><span class="s">&#34;name&#34;</span><span class="p">:</span> <span class="s">&#34;Alice&#34;</span><span class="p">&#125;</span><span class="p">)</span><span class="p">,</span>
+	<span class="p">)</span>
+
+	<span class="k">if</span> <span class="nx">res</span><span class="p">.</span><span class="nf">StatusCode</span><span class="p">(</span><span class="p">)</span> <span class="o">!=</span> <span class="mi">201</span> <span class="p">&#123;</span>
+		<span class="nx">t</span><span class="p">.</span><span class="nf">Fatalf</span><span class="p">(</span><span class="s">&#34;expected 201, got %d&#34;</span><span class="p">,</span> <span class="nx">res</span><span class="p">.</span><span class="nf">StatusCode</span><span class="p">(</span><span class="p">)</span><span class="p">)</span>
+	<span class="p">&#125;</span>
+<span class="p">&#125;</span></code></pre>
+		`,
+	)
+}

--- a/docs/templates/code/cookiegetgo.templ
+++ b/docs/templates/code/cookiegetgo.templ
@@ -1,0 +1,18 @@
+package code
+
+templ Cookiegetgo() {
+	@templ.Raw(
+		`
+			<pre class="chroma"><code><span class="nx">app</span><span class="p">.</span><span class="nf">Get</span><span class="p">(</span><span class="s">&#34;/me&#34;</span><span class="p">,</span> <span class="kd">func</span><span class="p">(</span><span class="nx">ctx</span> <span class="nx">MyContext</span><span class="p">)</span> <span class="kt">error</span> <span class="p">&#123;</span>
+	<span class="nx">c</span><span class="p">,</span> <span class="nx">ok</span> <span class="o">:=</span> <span class="nx">cookie</span><span class="p">.</span><span class="nf">GetCookie</span><span class="p">(</span><span class="nx">ctx</span><span class="p">,</span> <span class="s">&#34;session&#34;</span><span class="p">,</span> <span class="kc">nil</span><span class="p">)</span>
+	<span class="k">if</span> <span class="p">!</span><span class="nx">ok</span> <span class="p">&#123;</span>
+		<span class="k">return</span> <span class="nx">ctx</span><span class="p">.</span><span class="nf">Status</span><span class="p">(</span><span class="mi">401</span><span class="p">)</span><span class="p">.</span><span class="nf">Text</span><span class="p">(</span><span class="s">&#34;no session&#34;</span><span class="p">)</span>
+	<span class="p">&#125;</span>
+	<span class="k">return</span> <span class="nx">ctx</span><span class="p">.</span><span class="nf">Text</span><span class="p">(</span><span class="s">&#34;session: &#34;</span> <span class="o">+</span> <span class="nx">c</span><span class="p">.</span><span class="nx">Value</span><span class="p">)</span>
+<span class="p">&#125;</span><span class="p">)</span>
+
+<span class="c1">// read all cookies at once</span>
+<span class="nx">cookies</span> <span class="o">:=</span> <span class="nx">cookie</span><span class="p">.</span><span class="nf">GetCookies</span><span class="p">(</span><span class="nx">ctx</span><span class="p">)</span></code></pre>
+		`,
+	)
+}

--- a/docs/templates/code/cookiesetgo.templ
+++ b/docs/templates/code/cookiesetgo.templ
@@ -1,0 +1,15 @@
+package code
+
+templ Cookiesetgo() {
+	@templ.Raw(
+		`
+			<pre class="chroma"><code><span class="kn">import</span> <span class="s">&#34;github.com/poteto0/takibi/cookie&#34;</span>
+
+<span class="nx">app</span><span class="p">.</span><span class="nf">Post</span><span class="p">(</span><span class="s">&#34;/login&#34;</span><span class="p">,</span> <span class="kd">func</span><span class="p">(</span><span class="nx">ctx</span> <span class="nx">MyContext</span><span class="p">)</span> <span class="kt">error</span> <span class="p">&#123;</span>
+	<span class="c1">// DefaultCookieOptions: Secure=true, HttpOnly=true, SameSite=Strict</span>
+	<span class="nx">cookie</span><span class="p">.</span><span class="nf">SetCookie</span><span class="p">(</span><span class="nx">ctx</span><span class="p">,</span> <span class="s">&#34;session&#34;</span><span class="p">,</span> <span class="s">&#34;abc123&#34;</span><span class="p">,</span> <span class="kc">nil</span><span class="p">)</span>
+	<span class="k">return</span> <span class="nx">ctx</span><span class="p">.</span><span class="nf">Status</span><span class="p">(</span><span class="mi">200</span><span class="p">)</span><span class="p">.</span><span class="nf">Text</span><span class="p">(</span><span class="s">&#34;logged in&#34;</span><span class="p">)</span>
+<span class="p">&#125;</span><span class="p">)</span></code></pre>
+		`,
+	)
+}

--- a/docs/templates/code/cookiesignedgo.templ
+++ b/docs/templates/code/cookiesignedgo.templ
@@ -1,0 +1,22 @@
+package code
+
+templ Cookiesignedgo() {
+	@templ.Raw(
+		`
+			<pre class="chroma"><code><span class="kd">const</span> <span class="nx">secret</span> <span class="p">=</span> <span class="s">&#34;my-signing-secret-min-32-chars!!&#34;</span>
+
+<span class="nx">app</span><span class="p">.</span><span class="nf">Post</span><span class="p">(</span><span class="s">&#34;/login&#34;</span><span class="p">,</span> <span class="kd">func</span><span class="p">(</span><span class="nx">ctx</span> <span class="nx">MyContext</span><span class="p">)</span> <span class="kt">error</span> <span class="p">&#123;</span>
+	<span class="nx">cookie</span><span class="p">.</span><span class="nf">SetSignedCookie</span><span class="p">(</span><span class="nx">ctx</span><span class="p">,</span> <span class="s">&#34;user_id&#34;</span><span class="p">,</span> <span class="s">&#34;42&#34;</span><span class="p">,</span> <span class="nx">secret</span><span class="p">,</span> <span class="kc">nil</span><span class="p">)</span>
+	<span class="k">return</span> <span class="nx">ctx</span><span class="p">.</span><span class="nf">Text</span><span class="p">(</span><span class="s">&#34;logged in&#34;</span><span class="p">)</span>
+<span class="p">&#125;</span><span class="p">)</span>
+
+<span class="nx">app</span><span class="p">.</span><span class="nf">Get</span><span class="p">(</span><span class="s">&#34;/me&#34;</span><span class="p">,</span> <span class="kd">func</span><span class="p">(</span><span class="nx">ctx</span> <span class="nx">MyContext</span><span class="p">)</span> <span class="kt">error</span> <span class="p">&#123;</span>
+	<span class="nx">c</span><span class="p">,</span> <span class="nx">ok</span> <span class="o">:=</span> <span class="nx">cookie</span><span class="p">.</span><span class="nf">GetSignedCookie</span><span class="p">(</span><span class="nx">ctx</span><span class="p">,</span> <span class="s">&#34;user_id&#34;</span><span class="p">,</span> <span class="nx">secret</span><span class="p">,</span> <span class="kc">nil</span><span class="p">)</span>
+	<span class="k">if</span> <span class="p">!</span><span class="nx">ok</span> <span class="p">&#123;</span>
+		<span class="k">return</span> <span class="nx">ctx</span><span class="p">.</span><span class="nf">Status</span><span class="p">(</span><span class="mi">401</span><span class="p">)</span><span class="p">.</span><span class="nf">Text</span><span class="p">(</span><span class="s">&#34;invalid or missing cookie&#34;</span><span class="p">)</span>
+	<span class="p">&#125;</span>
+	<span class="k">return</span> <span class="nx">ctx</span><span class="p">.</span><span class="nf">Text</span><span class="p">(</span><span class="s">&#34;user: &#34;</span> <span class="o">+</span> <span class="nx">c</span><span class="p">.</span><span class="nx">Value</span><span class="p">)</span> <span class="c1">// &#34;42&#34;</span>
+<span class="p">&#125;</span><span class="p">)</span></code></pre>
+		`,
+	)
+}

--- a/docs/templates/code/factorymiddlewarego.templ
+++ b/docs/templates/code/factorymiddlewarego.templ
@@ -1,0 +1,23 @@
+package code
+
+templ Factorymiddlewarego() {
+	@templ.Raw(
+		`
+			<pre class="chroma"><code><span class="kn">import</span> <span class="s">&#34;github.com/poteto0/takibi/factory&#34;</span>
+
+<span class="nx">auth</span> <span class="o">:=</span> <span class="nx">factory</span><span class="p">.</span><span class="nf">CreateMiddleware</span><span class="p">(</span>
+	<span class="kd">func</span><span class="p">(</span><span class="nx">ctx</span> <span class="nx">MyContext</span><span class="p">,</span> <span class="nx">next</span> <span class="nx">interfaces</span><span class="p">.</span><span class="nx">HandlerFunc</span><span class="p">[</span><span class="nx">Bindings</span><span class="p">]</span><span class="p">)</span> <span class="nx">interfaces</span><span class="p">.</span><span class="nx">HandlerFunc</span><span class="p">[</span><span class="nx">Bindings</span><span class="p">]</span> <span class="p">&#123;</span>
+		<span class="k">return</span> <span class="kd">func</span><span class="p">(</span><span class="nx">ctx</span> <span class="nx">MyContext</span><span class="p">)</span> <span class="kt">error</span> <span class="p">&#123;</span>
+			<span class="nx">token</span> <span class="o">:=</span> <span class="nx">ctx</span><span class="p">.</span><span class="nf">Req</span><span class="p">(</span><span class="p">)</span><span class="p">.</span><span class="nf">HeaderBy</span><span class="p">(</span><span class="s">&#34;Authorization&#34;</span><span class="p">)</span>
+			<span class="k">if</span> <span class="nx">token</span> <span class="o">==</span> <span class="s">&#34;&#34;</span> <span class="p">&#123;</span>
+				<span class="k">return</span> <span class="nx">ctx</span><span class="p">.</span><span class="nf">Status</span><span class="p">(</span><span class="mi">401</span><span class="p">)</span><span class="p">.</span><span class="nf">Text</span><span class="p">(</span><span class="s">&#34;unauthorized&#34;</span><span class="p">)</span>
+			<span class="p">&#125;</span>
+			<span class="k">return</span> <span class="nf">next</span><span class="p">(</span><span class="nx">ctx</span><span class="p">)</span>
+		<span class="p">&#125;</span>
+	<span class="p">&#125;</span><span class="p">,</span>
+<span class="p">)</span>
+
+<span class="nx">app</span><span class="p">.</span><span class="nf">Use</span><span class="p">(</span><span class="s">&#34;/protected&#34;</span><span class="p">,</span> <span class="nx">auth</span><span class="p">)</span></code></pre>
+		`,
+	)
+}

--- a/docs/templates/code/factoryparamgo.templ
+++ b/docs/templates/code/factoryparamgo.templ
@@ -1,0 +1,17 @@
+package code
+
+templ Factoryparamgo() {
+	@templ.Raw(
+		`
+			<pre class="chroma"><code><span class="kn">import</span> <span class="s">&#34;github.com/poteto0/takibi/factory&#34;</span>
+
+<span class="nx">app</span><span class="p">.</span><span class="nf">Get</span><span class="p">(</span><span class="s">&#34;/users/:id&#34;</span><span class="p">,</span> <span class="kd">func</span><span class="p">(</span><span class="nx">ctx</span> <span class="nx">MyContext</span><span class="p">)</span> <span class="kt">error</span> <span class="p">&#123;</span>
+	<span class="nx">id</span><span class="p">,</span> <span class="nx">err</span> <span class="o">:=</span> <span class="nx">factory</span><span class="p">.</span><span class="nx">ParamBy</span><span class="p">[</span><span class="kt">int</span><span class="p">]</span><span class="p">(</span><span class="nx">ctx</span><span class="p">,</span> <span class="s">&#34;id&#34;</span><span class="p">)</span>
+	<span class="k">if</span> <span class="nx">err</span> <span class="o">!=</span> <span class="kc">nil</span> <span class="p">&#123;</span>
+		<span class="k">return</span> <span class="nx">ctx</span><span class="p">.</span><span class="nf">Status</span><span class="p">(</span><span class="mi">400</span><span class="p">)</span><span class="p">.</span><span class="nf">Text</span><span class="p">(</span><span class="s">&#34;invalid id&#34;</span><span class="p">)</span>
+	<span class="p">&#125;</span>
+	<span class="k">return</span> <span class="nx">ctx</span><span class="p">.</span><span class="nf">Json</span><span class="p">(</span><span class="kd">map</span><span class="p">[</span><span class="kt">string</span><span class="p">]</span><span class="kt">int</span><span class="p">&#123;</span><span class="s">&#34;id&#34;</span><span class="p">:</span> <span class="nx">id</span><span class="p">&#125;</span><span class="p">)</span>
+<span class="p">&#125;</span><span class="p">)</span></code></pre>
+		`,
+	)
+}

--- a/docs/templates/code/factoryquerygo.templ
+++ b/docs/templates/code/factoryquerygo.templ
@@ -1,0 +1,15 @@
+package code
+
+templ Factoryquerygo() {
+	@templ.Raw(
+		`
+			<pre class="chroma"><code><span class="nx">app</span><span class="p">.</span><span class="nf">Get</span><span class="p">(</span><span class="s">&#34;/users&#34;</span><span class="p">,</span> <span class="kd">func</span><span class="p">(</span><span class="nx">ctx</span> <span class="nx">MyContext</span><span class="p">)</span> <span class="kt">error</span> <span class="p">&#123;</span>
+	<span class="nx">page</span><span class="p">,</span> <span class="nx">err</span> <span class="o">:=</span> <span class="nx">factory</span><span class="p">.</span><span class="nx">QueryBy</span><span class="p">[</span><span class="kt">int</span><span class="p">]</span><span class="p">(</span><span class="nx">ctx</span><span class="p">,</span> <span class="s">&#34;page&#34;</span><span class="p">)</span>
+	<span class="k">if</span> <span class="nx">err</span> <span class="o">!=</span> <span class="kc">nil</span> <span class="p">&#123;</span>
+		<span class="k">return</span> <span class="nx">ctx</span><span class="p">.</span><span class="nf">Status</span><span class="p">(</span><span class="mi">400</span><span class="p">)</span><span class="p">.</span><span class="nf">Text</span><span class="p">(</span><span class="s">&#34;invalid page&#34;</span><span class="p">)</span>
+	<span class="p">&#125;</span>
+	<span class="k">return</span> <span class="nx">ctx</span><span class="p">.</span><span class="nf">Json</span><span class="p">(</span><span class="kd">map</span><span class="p">[</span><span class="kt">string</span><span class="p">]</span><span class="kt">int</span><span class="p">&#123;</span><span class="s">&#34;page&#34;</span><span class="p">:</span> <span class="nx">page</span><span class="p">&#125;</span><span class="p">)</span>
+<span class="p">&#125;</span><span class="p">)</span></code></pre>
+		`,
+	)
+}

--- a/docs/templates/code/middlewarecorsgo.templ
+++ b/docs/templates/code/middlewarecorsgo.templ
@@ -1,0 +1,22 @@
+package code
+
+templ Middlewarecorsgo() {
+	@templ.Raw(
+		`
+			<pre class="chroma"><code><span class="kn">import</span> <span class="s">&#34;github.com/poteto0/takibi/middlewares&#34;</span>
+
+<span class="c1">// Apply default CORS to all routes (allows *)</span>
+<span class="nx">app</span><span class="p">.</span><span class="nf">Use</span><span class="p">(</span><span class="s">&#34;/&#34;</span><span class="p">,</span> <span class="nx">middlewares</span><span class="p">.</span><span class="nx">Cors</span><span class="p">[</span><span class="nx">Bindings</span><span class="p">]</span><span class="p">(</span><span class="p">)</span><span class="p">)</span>
+
+<span class="c1">// Custom CORS config</span>
+<span class="nx">cfg</span> <span class="o">:=</span> <span class="nx">middlewares</span><span class="p">.</span><span class="nx">CorsConfig</span><span class="p">&#123;</span>
+	<span class="nx">AllowOrigins</span><span class="p">:</span>     <span class="p">[</span><span class="p">]</span><span class="kt">string</span><span class="p">&#123;</span><span class="s">&#34;https://example.com&#34;</span><span class="p">&#125;</span><span class="p">,</span>
+	<span class="nx">AllowMethods</span><span class="p">:</span>     <span class="p">[</span><span class="p">]</span><span class="kt">string</span><span class="p">&#123;</span><span class="s">&#34;GET&#34;</span><span class="p">,</span> <span class="s">&#34;POST&#34;</span><span class="p">,</span> <span class="s">&#34;PUT&#34;</span><span class="p">,</span> <span class="s">&#34;DELETE&#34;</span><span class="p">&#125;</span><span class="p">,</span>
+	<span class="nx">AllowHeaders</span><span class="p">:</span>     <span class="p">[</span><span class="p">]</span><span class="kt">string</span><span class="p">&#123;</span><span class="s">&#34;Content-Type&#34;</span><span class="p">,</span> <span class="s">&#34;Authorization&#34;</span><span class="p">&#125;</span><span class="p">,</span>
+	<span class="nx">AllowCredentials</span><span class="p">:</span> <span class="kc">true</span><span class="p">,</span>
+	<span class="nx">MaxAge</span><span class="p">:</span>           <span class="mi">3600</span><span class="p">,</span>
+<span class="p">&#125;</span>
+<span class="nx">app</span><span class="p">.</span><span class="nf">Use</span><span class="p">(</span><span class="s">&#34;/api&#34;</span><span class="p">,</span> <span class="nx">middlewares</span><span class="p">.</span><span class="nx">Cors</span><span class="p">[</span><span class="nx">Bindings</span><span class="p">]</span><span class="p">(</span><span class="nx">cfg</span><span class="p">)</span><span class="p">)</span></code></pre>
+		`,
+	)
+}

--- a/docs/templates/code/middlewarecustomgo.templ
+++ b/docs/templates/code/middlewarecustomgo.templ
@@ -1,0 +1,18 @@
+package code
+
+templ Middlewarecustomgo() {
+	@templ.Raw(
+		`
+			<pre class="chroma"><code><span class="kd">func</span> <span class="nf">AuthMiddleware</span><span class="p">(</span><span class="nx">ctx</span> <span class="nx">MyContext</span><span class="p">,</span> <span class="nx">next</span> <span class="nx">interfaces</span><span class="p">.</span><span class="nx">HandlerFunc</span><span class="p">[</span><span class="nx">Bindings</span><span class="p">]</span><span class="p">)</span> <span class="kt">error</span> <span class="p">&#123;</span>
+	<span class="nx">token</span> <span class="o">:=</span> <span class="nx">ctx</span><span class="p">.</span><span class="nf">Req</span><span class="p">(</span><span class="p">)</span><span class="p">.</span><span class="nf">HeaderBy</span><span class="p">(</span><span class="s">&#34;Authorization&#34;</span><span class="p">)</span>
+	<span class="k">if</span> <span class="nx">token</span> <span class="o">==</span> <span class="s">&#34;&#34;</span> <span class="p">&#123;</span>
+		<span class="k">return</span> <span class="nx">ctx</span><span class="p">.</span><span class="nf">Status</span><span class="p">(</span><span class="mi">401</span><span class="p">)</span><span class="p">.</span><span class="nf">Text</span><span class="p">(</span><span class="s">&#34;unauthorized&#34;</span><span class="p">)</span>
+	<span class="p">&#125;</span>
+	<span class="k">return</span> <span class="nf">next</span><span class="p">(</span><span class="nx">ctx</span><span class="p">)</span>
+<span class="p">&#125;</span>
+
+<span class="nx">app</span><span class="p">.</span><span class="nf">Use</span><span class="p">(</span><span class="s">&#34;/protected&#34;</span><span class="p">,</span> <span class="nx">AuthMiddleware</span><span class="p">)</span>
+<span class="nx">app</span><span class="p">.</span><span class="nf">Get</span><span class="p">(</span><span class="s">&#34;/protected/me&#34;</span><span class="p">,</span> <span class="nx">meHandler</span><span class="p">)</span></code></pre>
+		`,
+	)
+}

--- a/docs/templates/code/middlewaretimeoutgo.templ
+++ b/docs/templates/code/middlewaretimeoutgo.templ
@@ -1,0 +1,20 @@
+package code
+
+templ Middlewaretimeoutgo() {
+	@templ.Raw(
+		`
+			<pre class="chroma"><code><span class="kn">import</span> <span class="p">(</span>
+	<span class="s">&#34;time&#34;</span>
+	<span class="s">&#34;github.com/poteto0/takibi/middlewares&#34;</span>
+<span class="p">)</span>
+
+<span class="c1">// All routes under /api time out after 5 seconds</span>
+<span class="nx">app</span><span class="p">.</span><span class="nf">Use</span><span class="p">(</span><span class="s">&#34;/api&#34;</span><span class="p">,</span> <span class="nx">middlewares</span><span class="p">.</span><span class="nx">Timeout</span><span class="p">[</span><span class="nx">Bindings</span><span class="p">]</span><span class="p">(</span><span class="mi">5</span><span class="o">*</span><span class="nx">time</span><span class="p">.</span><span class="nx">Second</span><span class="p">)</span><span class="p">)</span>
+
+<span class="nx">app</span><span class="p">.</span><span class="nf">Get</span><span class="p">(</span><span class="s">&#34;/api/slow&#34;</span><span class="p">,</span> <span class="kd">func</span><span class="p">(</span><span class="nx">ctx</span> <span class="nx">MyContext</span><span class="p">)</span> <span class="kt">error</span> <span class="p">&#123;</span>
+	<span class="nx">time</span><span class="p">.</span><span class="nf">Sleep</span><span class="p">(</span><span class="mi">10</span> <span class="o">*</span> <span class="nx">time</span><span class="p">.</span><span class="nx">Second</span><span class="p">)</span> <span class="c1">// returns ErrRequestTimeout</span>
+	<span class="k">return</span> <span class="nx">ctx</span><span class="p">.</span><span class="nf">Text</span><span class="p">(</span><span class="s">&#34;done&#34;</span><span class="p">)</span>
+<span class="p">&#125;</span><span class="p">)</span></code></pre>
+		`,
+	)
+}

--- a/docs/templates/code/subroutego.templ
+++ b/docs/templates/code/subroutego.templ
@@ -1,0 +1,23 @@
+package code
+
+templ Subroutego() {
+	@templ.Raw(
+		`
+			<pre class="chroma"><code><span class="c1">// build a sub-app</span>
+<span class="nx">api</span> <span class="o">:=</span> <span class="nx">takibi</span><span class="p">.</span><span class="nx">New</span><span class="p">[</span><span class="nx">Bindings</span><span class="p">]</span><span class="p">(</span><span class="nx">bindings</span><span class="p">)</span>
+<span class="nx">api</span><span class="p">.</span><span class="nf">Get</span><span class="p">(</span><span class="s">&#34;/users&#34;</span><span class="p">,</span> <span class="nx">listUsers</span><span class="p">)</span>
+<span class="nx">api</span><span class="p">.</span><span class="nf">Post</span><span class="p">(</span><span class="s">&#34;/users&#34;</span><span class="p">,</span> <span class="nx">createUser</span><span class="p">)</span>
+<span class="nx">api</span><span class="p">.</span><span class="nf">Get</span><span class="p">(</span><span class="s">&#34;/users/:id&#34;</span><span class="p">,</span> <span class="nx">getUser</span><span class="p">)</span>
+
+<span class="c1">// mount it under /api/v1</span>
+<span class="nx">app</span> <span class="o">:=</span> <span class="nx">takibi</span><span class="p">.</span><span class="nx">New</span><span class="p">[</span><span class="nx">Bindings</span><span class="p">]</span><span class="p">(</span><span class="nx">bindings</span><span class="p">)</span>
+<span class="nx">app</span><span class="p">.</span><span class="nf">Route</span><span class="p">(</span><span class="s">&#34;/api/v1&#34;</span><span class="p">,</span> <span class="nx">api</span><span class="p">)</span>
+
+<span class="c1">// registered routes:</span>
+<span class="c1">//   GET  /api/v1/users</span>
+<span class="c1">//   POST /api/v1/users</span>
+<span class="c1">//   GET  /api/v1/users/:id</span>
+<span class="nx">app</span><span class="p">.</span><span class="nf">Fire</span><span class="p">(</span><span class="s">&#34;:8000&#34;</span><span class="p">)</span></code></pre>
+		`,
+	)
+}

--- a/docs/templates/layouts/helpers.go
+++ b/docs/templates/layouts/helpers.go
@@ -1,0 +1,10 @@
+package layouts
+
+func inSection(active string, members ...string) bool {
+	for _, m := range members {
+		if active == m {
+			return true
+		}
+	}
+	return false
+}

--- a/docs/templates/layouts/layout.templ
+++ b/docs/templates/layouts/layout.templ
@@ -26,23 +26,32 @@ templ Layout(title string, active string, content templ.Component) {
 			<div class={ styles.PageWrapper() }>
 				if active != "home" {
 					<nav class={ styles.Sidebar(), "sidebar-scroll" }>
-						<details class="sidebar-details" open?={ active == "getting-started" || active == "cloudflare-workers" }>
+						<details class="sidebar-details" open?={ inSection(active, "getting-started", "cloudflare-workers") }>
 							<summary class={ styles.SidebarSectionTitle(), "sidebar-section-summary" }>
 								Getting Started
 							</summary>
 							<a href="/getting-started/cloudflare-workers" class={ "sidebar-link", templ.KV("active", active == "cloudflare-workers") }>Cloudflare Workers</a>
 							<a href="/getting-started" class={ "sidebar-link", templ.KV("active", active == "getting-started") }>Native Go</a>
 						</details>
-						<details class="sidebar-details" open?={ active == "type-safe-context" || active == "routing" }>
+						<details class="sidebar-details" open?={ inSection(active, "type-safe-context", "routing", "sub-routing") }>
 							<summary class={ styles.SidebarSectionTitle(), "sidebar-section-summary" }>Core Concepts</summary>
 							<a href="/docs/type-safe-context" class={ "sidebar-link", templ.KV("active", active == "type-safe-context") }>Type-Safe Context</a>
 							<a href="/docs/routing" class={ "sidebar-link", templ.KV("active", active == "routing") }>Routing</a>
+							<a href="/docs/sub-routing" class={ "sidebar-link", templ.KV("active", active == "sub-routing") }>Sub-Routing</a>
 						</details>
-						<details class="sidebar-details" open?={ active == "redirect" || active == "error-handling" || active == "request-body" }>
+						<details class="sidebar-details" open?={ inSection(active, "middleware", "redirect", "error-handling", "request-body", "cookie") }>
 							<summary class={ styles.SidebarSectionTitle(), "sidebar-section-summary" }>Features</summary>
+							<a href="/docs/middleware" class={ "sidebar-link", templ.KV("active", active == "middleware") }>Middleware</a>
 							<a href="/docs/redirect" class={ "sidebar-link", templ.KV("active", active == "redirect") }>Redirect</a>
 							<a href="/docs/error-handling" class={ "sidebar-link", templ.KV("active", active == "error-handling") }>Error Handling</a>
 							<a href="/docs/request-body" class={ "sidebar-link", templ.KV("active", active == "request-body") }>Request Body</a>
+							<a href="/docs/cookie" class={ "sidebar-link", templ.KV("active", active == "cookie") }>Cookie</a>
+						</details>
+						<details class="sidebar-details" open?={ inSection(active, "factory", "testing", "blow") }>
+							<summary class={ styles.SidebarSectionTitle(), "sidebar-section-summary" }>Advanced</summary>
+							<a href="/docs/factory" class={ "sidebar-link", templ.KV("active", active == "factory") }>Factory Helpers</a>
+							<a href="/docs/testing" class={ "sidebar-link", templ.KV("active", active == "testing") }>Testing</a>
+							<a href="/docs/blow" class={ "sidebar-link", templ.KV("active", active == "blow") }>Background Tasks</a>
 						</details>
 					</nav>
 				}

--- a/docs/templates/pages/blow.templ
+++ b/docs/templates/pages/blow.templ
@@ -1,0 +1,59 @@
+package pages
+
+import "github.com/poteto0/takibi-docs/templates/styles"
+import "github.com/poteto0/takibi-docs/templates/code"
+
+templ Blow() {
+	<h1>Background Tasks</h1>
+	<p class={ styles.Lead() }><code>app.Blow</code> registers tasks that run outside the request lifecycle. Tasks can trigger on server start/stop, or run on a cron schedule.</p>
+	<div class={ styles.Callout(), styles.CalloutWarning() }>
+		Blow tasks are not supported on WASM / Cloudflare Workers. Use them only with the native Go server.
+	</div>
+	<h2>Trigger Tasks</h2>
+	<p>Set <code>BlowActionTag</code> to <code>&#34;trigger&#34;</code> and <code>BlowActionTrigger</code> to <code>&#34;start&#34;</code> or <code>&#34;stop&#34;</code> to run code when the server boots or shuts down:</p>
+	@code.Blowtriggergo()
+	<h2>Scheduled Tasks</h2>
+	<p>Set <code>BlowActionTag</code> to <code>&#34;schedule&#34;</code> and provide a cron expression in <code>BlowActionSchedule</code>. The scheduler uses <a href="https://pkg.go.dev/github.com/robfig/cron/v3" target="_blank" rel="noopener">robfig/cron</a> with optional seconds support:</p>
+	@code.Blowschedulego()
+	<h2>BlowTask Reference</h2>
+	<table>
+		<thead>
+			<tr>
+				<th>Field</th>
+				<th>Values</th>
+				<th>Description</th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr>
+				<td><code>BlowActionTag</code></td>
+				<td><code>&#34;trigger&#34;</code>, <code>&#34;schedule&#34;</code></td>
+				<td>Task type</td>
+			</tr>
+			<tr>
+				<td><code>BlowActionTrigger</code></td>
+				<td><code>&#34;start&#34;</code>, <code>&#34;stop&#34;</code></td>
+				<td>When to run (trigger tasks only)</td>
+			</tr>
+			<tr>
+				<td><code>BlowActionSchedule</code></td>
+				<td>cron expression</td>
+				<td>Schedule (schedule tasks only)</td>
+			</tr>
+			<tr>
+				<td><code>BlowAction</code></td>
+				<td><code>func(IContext[B]) error</code></td>
+				<td>The task function</td>
+			</tr>
+		</tbody>
+	</table>
+	<p>Handle task errors with <code>app.OnBlowError</code>:</p>
+	<pre>
+		<span class={ styles.PreLabel() }>go</span>
+		<code>
+			app.OnBlowError(func(ctx MyContext, err error) &#123;
+			log.Printf(&#34;background task failed: %v&#34;, err)
+			&#125;)
+		</code>
+	</pre>
+}

--- a/docs/templates/pages/cookie.templ
+++ b/docs/templates/pages/cookie.templ
@@ -1,0 +1,58 @@
+package pages
+
+import "github.com/poteto0/takibi-docs/templates/styles"
+import "github.com/poteto0/takibi-docs/templates/code"
+
+templ Cookie() {
+	<h1>Cookie</h1>
+	<p class={ styles.Lead() }>The <code>cookie</code> package provides helpers for setting, getting, and signing cookies with sensible secure defaults. All helpers require the context, so they work inside any handler.</p>
+	<h2>Set Cookie</h2>
+	<p><code>SetCookie</code> writes a cookie to the response. Passing <code>nil</code> as options uses <code>DefaultCookieOptions</code> — <code>Secure</code>, <code>HttpOnly</code>, and <code>SameSite=Strict</code>:</p>
+	@code.Cookiesetgo()
+	<h2>Get Cookie</h2>
+	<p><code>GetCookie</code> reads a single cookie by name. It returns a boolean second value so the zero-value string case is unambiguous:</p>
+	@code.Cookiegetgo()
+	<h2>Signed Cookies</h2>
+	<p>Signed cookies use HMAC to detect tampering. Use <code>SetSignedCookie</code> / <code>GetSignedCookie</code> with a shared secret:</p>
+	@code.Cookiesignedgo()
+	<div class={ styles.Callout(), styles.CalloutWarning() }>
+		The signing secret must be at least 32 bytes. Shorter secrets are rejected at runtime to prevent weak HMAC keys.
+	</div>
+	<h2>Options Reference</h2>
+	<table>
+		<thead>
+			<tr>
+				<th>Field</th>
+				<th>Default</th>
+				<th>Description</th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr>
+				<td><code>Secure</code></td>
+				<td><code>true</code></td>
+				<td>HTTPS only</td>
+			</tr>
+			<tr>
+				<td><code>HttpOnly</code></td>
+				<td><code>true</code></td>
+				<td>Not accessible via JS</td>
+			</tr>
+			<tr>
+				<td><code>SameSite</code></td>
+				<td><code>Strict</code></td>
+				<td>No cross-site sending</td>
+			</tr>
+			<tr>
+				<td><code>Path</code></td>
+				<td><code>/</code></td>
+				<td>Cookie scope path</td>
+			</tr>
+			<tr>
+				<td><code>Prefix</code></td>
+				<td><code>&#34;&#34;</code></td>
+				<td><code>&#34;secure&#34;</code> or <code>&#34;host&#34;</code> prefix mode</td>
+			</tr>
+		</tbody>
+	</table>
+}

--- a/docs/templates/pages/factory.templ
+++ b/docs/templates/pages/factory.templ
@@ -1,0 +1,21 @@
+package pages
+
+import "github.com/poteto0/takibi-docs/templates/styles"
+import "github.com/poteto0/takibi-docs/templates/code"
+
+templ Factory() {
+	<h1>Factory Helpers</h1>
+	<p class={ styles.Lead() }>The <code>factory</code> package provides generic helpers for converting path parameters and query strings to typed values, and for composing middleware with a handler-returning signature.</p>
+	<h2>Typed Path Parameters</h2>
+	<p><code>factory.ParamBy[T]</code> reads a path parameter and converts it to the requested type. Supported types: <code>int</code>, <code>int64</code>, <code>float64</code>, <code>bool</code>, <code>string</code>.</p>
+	@code.Factoryparamgo()
+	<h2>Typed Query Parameters</h2>
+	<p><code>factory.QueryBy[T]</code> reads the first value of a query key and converts it to the requested type:</p>
+	@code.Factoryquerygo()
+	<h2>CreateMiddleware</h2>
+	<p><code>factory.CreateMiddleware</code> wraps a function that returns a handler, adapting it to the standard <code>MiddlewareFunc</code> signature. This is useful when you need to inject transformed values into the next handler:</p>
+	@code.Factorymiddlewarego()
+	<div class={ styles.Callout() }>
+		<code>ParamBy</code> and <code>QueryBy</code> return a zero value (not an error) when the key is missing. Check the error only for conversion failures.
+	</div>
+}

--- a/docs/templates/pages/getting_started.templ
+++ b/docs/templates/pages/getting_started.templ
@@ -18,8 +18,14 @@ templ GettingStarted() {
 	<ul style="list-style:none;display:flex;flex-direction:column;gap:8px;margin-top:8px;">
 		<li><a href="/docs/type-safe-context" style="color:var(--primary);text-decoration:none;font-size:15px;">&#8594; Type-Safe Context</a></li>
 		<li><a href="/docs/routing" style="color:var(--primary);text-decoration:none;font-size:15px;">&#8594; Routing</a></li>
+		<li><a href="/docs/sub-routing" style="color:var(--primary);text-decoration:none;font-size:15px;">&#8594; Sub-Routing</a></li>
+		<li><a href="/docs/middleware" style="color:var(--primary);text-decoration:none;font-size:15px;">&#8594; Middleware</a></li>
 		<li><a href="/docs/redirect" style="color:var(--primary);text-decoration:none;font-size:15px;">&#8594; Redirect</a></li>
 		<li><a href="/docs/error-handling" style="color:var(--primary);text-decoration:none;font-size:15px;">&#8594; Error Handling</a></li>
 		<li><a href="/docs/request-body" style="color:var(--primary);text-decoration:none;font-size:15px;">&#8594; Request Body Size Limit</a></li>
+		<li><a href="/docs/cookie" style="color:var(--primary);text-decoration:none;font-size:15px;">&#8594; Cookie</a></li>
+		<li><a href="/docs/factory" style="color:var(--primary);text-decoration:none;font-size:15px;">&#8594; Factory Helpers</a></li>
+		<li><a href="/docs/testing" style="color:var(--primary);text-decoration:none;font-size:15px;">&#8594; Testing</a></li>
+		<li><a href="/docs/blow" style="color:var(--primary);text-decoration:none;font-size:15px;">&#8594; Background Tasks</a></li>
 	</ul>
 }

--- a/docs/templates/pages/middleware.templ
+++ b/docs/templates/pages/middleware.templ
@@ -1,0 +1,21 @@
+package pages
+
+import "github.com/poteto0/takibi-docs/templates/styles"
+import "github.com/poteto0/takibi-docs/templates/code"
+
+templ Middleware() {
+	<h1>Middleware</h1>
+	<p class={ styles.Lead() }>Middleware wraps handler execution, enabling cross-cutting concerns like CORS, authentication, and timeouts. Use <code>app.Use(path, middleware...)</code> to apply middleware to all routes under a path.</p>
+	<h2>CORS</h2>
+	<p>The built-in CORS middleware handles preflight requests and sets the appropriate response headers. With no arguments it allows all origins (<code>*</code>):</p>
+	@code.Middlewarecorsgo()
+	<div class={ styles.Callout() }>
+		The default config allows <code>GET</code>, <code>POST</code>, <code>HEAD</code>, <code>PUT</code>, <code>DELETE</code>, and <code>PATCH</code>, with a 24-hour preflight cache.
+	</div>
+	<h2>Timeout</h2>
+	<p>The timeout middleware cancels slow handlers and returns <code>constants.ErrRequestTimeout</code> when the deadline is exceeded:</p>
+	@code.Middlewaretimeoutgo()
+	<h2>Custom Middleware</h2>
+	<p>Any function with the signature <code>func(ctx, next) error</code> is a valid middleware. Call <code>next(ctx)</code> to continue the chain, or return early to short-circuit:</p>
+	@code.Middlewarecustomgo()
+}

--- a/docs/templates/pages/sub_routing.templ
+++ b/docs/templates/pages/sub_routing.templ
@@ -1,0 +1,29 @@
+package pages
+
+import "github.com/poteto0/takibi-docs/templates/styles"
+import "github.com/poteto0/takibi-docs/templates/code"
+
+templ SubRouting() {
+	<h1>Sub-Routing</h1>
+	<p class={ styles.Lead() }><code>app.Route</code> mounts a child app under a base path. Routes registered on the child app are prefixed and merged into the parent router, including any middleware attached to those routes.</p>
+	<h2>Mounting a Sub-App</h2>
+	@code.Subroutego()
+	<div class={ styles.Callout() }>
+		Middleware registered on the child app's routes is preserved when mounted. Middleware registered on the parent (via <code>app.Use</code>) applies to all merged routes.
+	</div>
+	<h2>All and On</h2>
+	<p><code>app.All</code> registers a handler for every HTTP method on a single path. <code>app.On</code> registers one handler across multiple methods and paths at once:</p>
+	<pre>
+		<span class={ styles.PreLabel() }>go</span>
+		<code>
+			// match any method
+			app.All(&#34;/ping&#34;, pingHandler)
+			// match selected methods across multiple paths
+			app.On(
+			[]string&#123;&#34;GET&#34;, &#34;POST&#34;&#125;,
+			[]string&#123;&#34;/items&#34;, &#34;/things&#34;&#125;,
+			handler,
+			)
+		</code>
+	</pre>
+}

--- a/docs/templates/pages/testing.templ
+++ b/docs/templates/pages/testing.templ
@@ -1,0 +1,50 @@
+package pages
+
+import "github.com/poteto0/takibi-docs/templates/styles"
+import "github.com/poteto0/takibi-docs/templates/code"
+
+templ Testing() {
+	<h1>Testing</h1>
+	<p class={ styles.Lead() }><code>app.Camp</code> simulates HTTP requests against the app without starting a server. It is the recommended way to write fast, dependency-free handler tests.</p>
+	<h2>GET Request</h2>
+	<p>Call <code>Camp(method, path)</code> and inspect the returned <code>ICampResponse</code>:</p>
+	@code.Campbasicgo()
+	<h2>POST with Body and Headers</h2>
+	<p>Pass <code>interfaces.Body</code> and <code>interfaces.Header</code> options to simulate a request with a body or custom headers:</p>
+	@code.Camppostgo()
+	<h2>ICampResponse Reference</h2>
+	<table>
+		<thead>
+			<tr>
+				<th>Method</th>
+				<th>Returns</th>
+				<th>Description</th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr>
+				<td><code>StatusCode()</code></td>
+				<td><code>int</code></td>
+				<td>HTTP status code</td>
+			</tr>
+			<tr>
+				<td><code>Raw()</code></td>
+				<td><code>*http.Response</code></td>
+				<td>Underlying response</td>
+			</tr>
+			<tr>
+				<td><code>Json()</code></td>
+				<td><code>(map[string]any, error)</code></td>
+				<td>Decode body as JSON map</td>
+			</tr>
+			<tr>
+				<td><code>Unmarshall(v)</code></td>
+				<td><code>error</code></td>
+				<td>Decode body into <code>v</code></td>
+			</tr>
+		</tbody>
+	</table>
+	<div class={ styles.Callout() }>
+		<code>Camp</code> does not start a network listener — it drives <code>ServeHTTP</code> directly via <code>httptest.NewRecorder</code>.
+	</div>
+}


### PR DESCRIPTION
## Summary

- Add 6 new doc pages covering the remaining public API surface: **Middleware** (CORS, Timeout, custom), **Cookie** (set/get/signed), **Factory Helpers** (`ParamBy[T]`, `QueryBy[T]`, `CreateMiddleware`), **Testing** (`app.Camp`), **Background Tasks** (`app.Blow`), and **Sub-Routing** (`app.Route` / `All` / `On`)
- Add 14 code example templates generated via `just gen-code` from new asset files
- Sidebar restructured into four sections: Getting Started, Core Concepts, Features, Advanced
- Getting Started next-steps links updated to cover all new pages

## Cleanup (from /simplify)

- **`docs/main.go`**: extract `docPage(title, active, component)` helper — collapses 14 × 3-line identical handler closures into 14 one-liners
- **`docs/templates/layouts/helpers.go`**: add `inSection(active, members...)` — replaces the growing `active == "a" || active == "b" || ...` OR-chains in each `<details open?=...>` with a readable call; adding a future page only requires the `<a>` link, not a manual edit to the condition

## Test plan

- [ ] `just gen` runs clean (templ generate produces no errors)
- [ ] `go build ./...` in `docs/` succeeds
- [ ] Visit each new page in the browser: `/docs/middleware`, `/docs/cookie`, `/docs/factory`, `/docs/testing`, `/docs/blow`, `/docs/sub-routing`
- [ ] Sidebar expands to the correct section on each page
- [ ] Getting Started next-steps links all resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)