### PR TITLE
ci(docs): fix templ setup and add workflow to trigger paths

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -6,11 +6,13 @@ on:
       - main
     paths:
       - 'docs/**'
+      - '.github/workflows/deploy-docs.yml'
   pull_request:
     branches:
       - main
     paths:
       - 'docs/**'
+      - '.github/workflows/deploy-docs.yml'
 
 env:
   GO_VERSION: "1.26.1"
@@ -31,9 +33,7 @@ jobs:
           cache-dependency-path: docs/go.sum
 
       - name: Setup templ
-        uses: a-h/setup-templ@v0
-        with:
-          version: ${{ env.TEMPL_VERSION }}
+        run: go install github.com/a-h/templ/cmd/templ@${{ env.TEMPL_VERSION }}
 
       - name: Setup just
         uses: extractions/setup-just@v4
@@ -73,9 +73,7 @@ jobs:
           cache-dependency-path: docs/go.sum
 
       - name: Setup templ
-        uses: a-h/setup-templ@v0
-        with:
-          version: ${{ env.TEMPL_VERSION }}
+        run: go install github.com/a-h/templ/cmd/templ@${{ env.TEMPL_VERSION }}
 
       - name: Setup just
         uses: extractions/setup-just@v4

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -42,6 +42,8 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
+        with:
+          package_json_file: docs/package.json
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -82,6 +84,8 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
+        with:
+          package_json_file: docs/package.json
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary

- Replace `a-h/setup-templ@v0` action with `go install github.com/a-h/templ/cmd/templ@<version>` — more reliable since it uses Go's own module proxy rather than a third-party action binary download
- Add `.github/workflows/deploy-docs.yml` to the `paths` filter on both `push` and `pull_request` triggers, so changes to the workflow file itself cause the workflow to run (enables testing CI fixes in PRs)

## Test plan

- [ ] Open this PR and confirm the `Deploy Docs` workflow triggers (path filter now includes the workflow file)
- [ ] Verify the `Setup templ` step succeeds via `go install`
- [ ] Confirm `just gen` → `templ generate` produces `_templ.go` files and the WASM build completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)