### PR TITLE
feat(validator): add FormFile multipart validator + validator docs

### DIFF
--- a/docs/main.go
+++ b/docs/main.go
@@ -39,6 +39,7 @@ func main() {
 	app.Get("/docs/redirect", docPage("Redirect", "redirect", pages.Redirect()))
 	app.Get("/docs/error-handling", docPage("Error Handling", "error-handling", pages.ErrorHandling()))
 	app.Get("/docs/request-body", docPage("Request Body", "request-body", pages.RequestBody()))
+	app.Get("/docs/validator", docPage("Validator", "validator", pages.Validator()))
 	app.Get("/docs/cookie", docPage("Cookie", "cookie", pages.Cookie()))
 
 	app.Get("/docs/factory", docPage("Factory Helpers", "factory", pages.Factory()))

--- a/docs/templates/code/validatorbasicgo.templ
+++ b/docs/templates/code/validatorbasicgo.templ
@@ -1,0 +1,18 @@
+package code
+
+templ Validatorbasicgo() {
+	@templ.Raw(
+		`
+			<pre class="chroma"><code><span class="nx">app</span><span class="p">.</span><span class="nf">Post</span><span class="p">(</span><span class="s">&#34;/posts&#34;</span><span class="p">,</span>
+	<span class="nx">validator</span><span class="p">.</span><span class="nf">Form</span><span class="p">(</span><span class="kd">func</span><span class="p">(</span><span class="nx">v</span> <span class="nx">url</span><span class="p">.</span><span class="nx">Values</span><span class="p">,</span> <span class="nx">c</span> <span class="nx">MyContext</span><span class="p">)</span> <span class="p">(</span><span class="nx">PostForm</span><span class="p">,</span> <span class="kt">error</span><span class="p">)</span> <span class="p">&#123;</span>
+		<span class="k">return</span> <span class="nx">PostForm</span><span class="p">&#123;</span><span class="nx">Body</span><span class="p">:</span> <span class="nx">v</span><span class="p">.</span><span class="nf">Get</span><span class="p">(</span><span class="s">&#34;body&#34;</span><span class="p">)</span><span class="p">&#125;</span><span class="p">,</span> <span class="kc">nil</span>
+	<span class="p">&#125;</span><span class="p">)</span><span class="p">,</span>
+	<span class="kd">func</span><span class="p">(</span><span class="nx">c</span> <span class="nx">MyContext</span><span class="p">)</span> <span class="kt">error</span> <span class="p">&#123;</span>
+		<span class="c1">// the value returned by the validator is stored under TargetForm</span>
+		<span class="nx">form</span><span class="p">,</span> <span class="nx">_</span> <span class="o">:=</span> <span class="nx">validator</span><span class="p">.</span><span class="nx">Valid</span><span class="p">[</span><span class="nx">PostForm</span><span class="p">]</span><span class="p">(</span><span class="nx">c</span><span class="p">,</span> <span class="nx">validator</span><span class="p">.</span><span class="nx">TargetForm</span><span class="p">)</span>
+		<span class="k">return</span> <span class="nx">c</span><span class="p">.</span><span class="nf">Status</span><span class="p">(</span><span class="mi">201</span><span class="p">)</span><span class="p">.</span><span class="nf">Text</span><span class="p">(</span><span class="nx">form</span><span class="p">.</span><span class="nx">Body</span><span class="p">)</span>
+	<span class="p">&#125;</span><span class="p">,</span>
+<span class="p">)</span></code></pre>
+		`,
+	)
+}

--- a/docs/templates/code/validatorerrorgo.templ
+++ b/docs/templates/code/validatorerrorgo.templ
@@ -1,0 +1,23 @@
+package code
+
+templ Validatorerrorgo() {
+	@templ.Raw(
+		`
+			<pre class="chroma"><code><span class="nx">validator</span><span class="p">.</span><span class="nf">Form</span><span class="p">(</span><span class="kd">func</span><span class="p">(</span><span class="nx">v</span> <span class="nx">url</span><span class="p">.</span><span class="nx">Values</span><span class="p">,</span> <span class="nx">c</span> <span class="nx">MyContext</span><span class="p">)</span> <span class="p">(</span><span class="nx">PostForm</span><span class="p">,</span> <span class="kt">error</span><span class="p">)</span> <span class="p">&#123;</span>
+	<span class="nx">body</span> <span class="o">:=</span> <span class="nx">v</span><span class="p">.</span><span class="nf">Get</span><span class="p">(</span><span class="s">&#34;body&#34;</span><span class="p">)</span>
+	<span class="k">if</span> <span class="nx">body</span> <span class="o">==</span> <span class="s">&#34;&#34;</span> <span class="p">&#123;</span>
+		<span class="c1">// Pattern A — write the response inline, then halt the chain.</span>
+		<span class="c1">// The error handler is NOT invoked.</span>
+		<span class="nx">c</span><span class="p">.</span><span class="nf">Status</span><span class="p">(</span><span class="mi">422</span><span class="p">)</span><span class="p">.</span><span class="nf">Text</span><span class="p">(</span><span class="s">&#34;body required&#34;</span><span class="p">)</span>
+		<span class="k">return</span> <span class="nx">PostForm</span><span class="p">&#123;</span><span class="p">&#125;</span><span class="p">,</span> <span class="nx">validator</span><span class="p">.</span><span class="nx">ErrStop</span>
+	<span class="p">&#125;</span>
+	<span class="k">if</span> <span class="nb">len</span><span class="p">(</span><span class="nx">body</span><span class="p">)</span> <span class="p">&gt;</span> <span class="mi">140</span> <span class="p">&#123;</span>
+		<span class="c1">// Pattern B — return a normal error; it flows to app.OnError</span>
+		<span class="c1">// so you can render validation failures in one central place.</span>
+		<span class="k">return</span> <span class="nx">PostForm</span><span class="p">&#123;</span><span class="p">&#125;</span><span class="p">,</span> <span class="nx">errors</span><span class="p">.</span><span class="nf">New</span><span class="p">(</span><span class="s">&#34;body too long&#34;</span><span class="p">)</span>
+	<span class="p">&#125;</span>
+	<span class="k">return</span> <span class="nx">PostForm</span><span class="p">&#123;</span><span class="nx">Body</span><span class="p">:</span> <span class="nx">body</span><span class="p">&#125;</span><span class="p">,</span> <span class="kc">nil</span>
+<span class="p">&#125;</span><span class="p">)</span></code></pre>
+		`,
+	)
+}

--- a/docs/templates/code/validatorformfilego.templ
+++ b/docs/templates/code/validatorformfilego.templ
@@ -1,0 +1,34 @@
+package code
+
+templ Validatorformfilego() {
+	@templ.Raw(
+		`
+			<pre class="chroma"><code><span class="nx">app</span><span class="p">.</span><span class="nf">Post</span><span class="p">(</span><span class="s">&#34;/upload&#34;</span><span class="p">,</span>
+	<span class="nx">validator</span><span class="p">.</span><span class="nf">FormFile</span><span class="p">(</span><span class="kd">func</span><span class="p">(</span><span class="nx">form</span> <span class="o">*</span><span class="nx">multipart</span><span class="p">.</span><span class="nx">Form</span><span class="p">,</span> <span class="nx">c</span> <span class="nx">MyContext</span><span class="p">)</span> <span class="p">(</span><span class="nx">Upload</span><span class="p">,</span> <span class="kt">error</span><span class="p">)</span> <span class="p">&#123;</span>
+		<span class="nx">files</span> <span class="o">:=</span> <span class="nx">form</span><span class="p">.</span><span class="nx">File</span><span class="p">[</span><span class="s">&#34;avatar&#34;</span><span class="p">]</span>
+		<span class="k">if</span> <span class="nb">len</span><span class="p">(</span><span class="nx">files</span><span class="p">)</span> <span class="o">==</span> <span class="mi">0</span> <span class="p">&#123;</span>
+			<span class="nx">c</span><span class="p">.</span><span class="nf">Status</span><span class="p">(</span><span class="mi">422</span><span class="p">)</span><span class="p">.</span><span class="nf">Text</span><span class="p">(</span><span class="s">&#34;avatar required&#34;</span><span class="p">)</span>
+			<span class="k">return</span> <span class="nx">Upload</span><span class="p">&#123;</span><span class="p">&#125;</span><span class="p">,</span> <span class="nx">validator</span><span class="p">.</span><span class="nx">ErrStop</span>
+		<span class="p">&#125;</span>
+
+		<span class="nx">f</span><span class="p">,</span> <span class="nx">err</span> <span class="o">:=</span> <span class="nx">files</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span><span class="p">.</span><span class="nf">Open</span><span class="p">(</span><span class="p">)</span>
+		<span class="k">if</span> <span class="nx">err</span> <span class="o">!=</span> <span class="kc">nil</span> <span class="p">&#123;</span>
+			<span class="k">return</span> <span class="nx">Upload</span><span class="p">&#123;</span><span class="p">&#125;</span><span class="p">,</span> <span class="nx">err</span> <span class="c1">// flows to app.OnError</span>
+		<span class="p">&#125;</span>
+		<span class="k">defer</span> <span class="nx">f</span><span class="p">.</span><span class="nf">Close</span><span class="p">(</span><span class="p">)</span>
+
+		<span class="c1">// form.Value holds the text fields, form.File the uploaded files.</span>
+		<span class="c1">// Parsing is done fully in memory, so it behaves the same on wasm.</span>
+		<span class="k">return</span> <span class="nx">Upload</span><span class="p">&#123;</span>
+			<span class="nx">Title</span><span class="p">:</span>    <span class="nx">form</span><span class="p">.</span><span class="nx">Value</span><span class="p">[</span><span class="s">&#34;title&#34;</span><span class="p">]</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span><span class="p">,</span>
+			<span class="nx">Filename</span><span class="p">:</span> <span class="nx">files</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span><span class="p">.</span><span class="nx">Filename</span><span class="p">,</span>
+		<span class="p">&#125;</span><span class="p">,</span> <span class="kc">nil</span>
+	<span class="p">&#125;</span><span class="p">)</span><span class="p">,</span>
+	<span class="kd">func</span><span class="p">(</span><span class="nx">c</span> <span class="nx">MyContext</span><span class="p">)</span> <span class="kt">error</span> <span class="p">&#123;</span>
+		<span class="nx">up</span><span class="p">,</span> <span class="nx">_</span> <span class="o">:=</span> <span class="nx">validator</span><span class="p">.</span><span class="nx">Valid</span><span class="p">[</span><span class="nx">Upload</span><span class="p">]</span><span class="p">(</span><span class="nx">c</span><span class="p">,</span> <span class="nx">validator</span><span class="p">.</span><span class="nx">TargetFormFile</span><span class="p">)</span>
+		<span class="k">return</span> <span class="nx">c</span><span class="p">.</span><span class="nf">Status</span><span class="p">(</span><span class="mi">201</span><span class="p">)</span><span class="p">.</span><span class="nf">Text</span><span class="p">(</span><span class="nx">up</span><span class="p">.</span><span class="nx">Filename</span><span class="p">)</span>
+	<span class="p">&#125;</span><span class="p">,</span>
+<span class="p">)</span></code></pre>
+		`,
+	)
+}

--- a/docs/templates/code/validatorformfilego.templ
+++ b/docs/templates/code/validatorformfilego.templ
@@ -5,23 +5,31 @@ templ Validatorformfilego() {
 		`
 			<pre class="chroma"><code><span class="nx">app</span><span class="p">.</span><span class="nf">Post</span><span class="p">(</span><span class="s">&#34;/upload&#34;</span><span class="p">,</span>
 	<span class="nx">validator</span><span class="p">.</span><span class="nf">FormFile</span><span class="p">(</span><span class="kd">func</span><span class="p">(</span><span class="nx">form</span> <span class="o">*</span><span class="nx">multipart</span><span class="p">.</span><span class="nx">Form</span><span class="p">,</span> <span class="nx">c</span> <span class="nx">MyContext</span><span class="p">)</span> <span class="p">(</span><span class="nx">Upload</span><span class="p">,</span> <span class="kt">error</span><span class="p">)</span> <span class="p">&#123;</span>
+		<span class="c1">// form.File holds the uploaded files keyed by field name.</span>
 		<span class="nx">files</span> <span class="o">:=</span> <span class="nx">form</span><span class="p">.</span><span class="nx">File</span><span class="p">[</span><span class="s">&#34;avatar&#34;</span><span class="p">]</span>
 		<span class="k">if</span> <span class="nb">len</span><span class="p">(</span><span class="nx">files</span><span class="p">)</span> <span class="o">==</span> <span class="mi">0</span> <span class="p">&#123;</span>
 			<span class="nx">c</span><span class="p">.</span><span class="nf">Status</span><span class="p">(</span><span class="mi">422</span><span class="p">)</span><span class="p">.</span><span class="nf">Text</span><span class="p">(</span><span class="s">&#34;avatar required&#34;</span><span class="p">)</span>
 			<span class="k">return</span> <span class="nx">Upload</span><span class="p">&#123;</span><span class="p">&#125;</span><span class="p">,</span> <span class="nx">validator</span><span class="p">.</span><span class="nx">ErrStop</span>
 		<span class="p">&#125;</span>
 
+		<span class="c1">// open the *multipart.FileHeader to get a multipart.File to read.</span>
 		<span class="nx">f</span><span class="p">,</span> <span class="nx">err</span> <span class="o">:=</span> <span class="nx">files</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span><span class="p">.</span><span class="nf">Open</span><span class="p">(</span><span class="p">)</span>
 		<span class="k">if</span> <span class="nx">err</span> <span class="o">!=</span> <span class="kc">nil</span> <span class="p">&#123;</span>
 			<span class="k">return</span> <span class="nx">Upload</span><span class="p">&#123;</span><span class="p">&#125;</span><span class="p">,</span> <span class="nx">err</span> <span class="c1">// flows to app.OnError</span>
 		<span class="p">&#125;</span>
 		<span class="k">defer</span> <span class="nx">f</span><span class="p">.</span><span class="nf">Close</span><span class="p">(</span><span class="p">)</span>
 
-		<span class="c1">// form.Value holds the text fields, form.File the uploaded files.</span>
-		<span class="c1">// Parsing is done fully in memory, so it behaves the same on wasm.</span>
+		<span class="nx">content</span><span class="p">,</span> <span class="nx">err</span> <span class="o">:=</span> <span class="nx">io</span><span class="p">.</span><span class="nf">ReadAll</span><span class="p">(</span><span class="nx">f</span><span class="p">)</span>
+		<span class="k">if</span> <span class="nx">err</span> <span class="o">!=</span> <span class="kc">nil</span> <span class="p">&#123;</span>
+			<span class="k">return</span> <span class="nx">Upload</span><span class="p">&#123;</span><span class="p">&#125;</span><span class="p">,</span> <span class="nx">err</span>
+		<span class="p">&#125;</span>
+
+		<span class="c1">// form.Value holds the text fields. Parsing is done fully in</span>
+		<span class="c1">// memory, so this behaves the same on native and wasm builds.</span>
 		<span class="k">return</span> <span class="nx">Upload</span><span class="p">&#123;</span>
 			<span class="nx">Title</span><span class="p">:</span>    <span class="nx">form</span><span class="p">.</span><span class="nx">Value</span><span class="p">[</span><span class="s">&#34;title&#34;</span><span class="p">]</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span><span class="p">,</span>
 			<span class="nx">Filename</span><span class="p">:</span> <span class="nx">files</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span><span class="p">.</span><span class="nx">Filename</span><span class="p">,</span>
+			<span class="nx">Content</span><span class="p">:</span>  <span class="nb">string</span><span class="p">(</span><span class="nx">content</span><span class="p">)</span><span class="p">,</span>
 		<span class="p">&#125;</span><span class="p">,</span> <span class="kc">nil</span>
 	<span class="p">&#125;</span><span class="p">)</span><span class="p">,</span>
 	<span class="kd">func</span><span class="p">(</span><span class="nx">c</span> <span class="nx">MyContext</span><span class="p">)</span> <span class="kt">error</span> <span class="p">&#123;</span>

--- a/docs/templates/code/validatorunmarshallgo.templ
+++ b/docs/templates/code/validatorunmarshallgo.templ
@@ -1,0 +1,26 @@
+package code
+
+templ Validatorunmarshallgo() {
+	@templ.Raw(
+		`
+			<pre class="chroma"><code><span class="kd">type</span> <span class="nx">User</span> <span class="kd">struct</span> <span class="p">&#123;</span>
+	<span class="nx">Name</span> <span class="kt">string</span> <span class="s">&#96;</span><span class="s">json:&#34;name&#34;</span><span class="s">&#96;</span>
+	<span class="nx">Age</span>  <span class="kt">int</span>    <span class="s">&#96;</span><span class="s">json:&#34;age&#34;</span><span class="s">&#96;</span>
+<span class="p">&#125;</span>
+
+<span class="nx">app</span><span class="p">.</span><span class="nf">Post</span><span class="p">(</span><span class="s">&#34;/users&#34;</span><span class="p">,</span>
+	<span class="nx">validator</span><span class="p">.</span><span class="nf">Unmarshall</span><span class="p">(</span><span class="kd">func</span><span class="p">(</span><span class="nx">u</span> <span class="nx">User</span><span class="p">,</span> <span class="nx">c</span> <span class="nx">MyContext</span><span class="p">)</span> <span class="p">(</span><span class="nx">User</span><span class="p">,</span> <span class="kt">error</span><span class="p">)</span> <span class="p">&#123;</span>
+		<span class="k">if</span> <span class="nx">u</span><span class="p">.</span><span class="nx">Name</span> <span class="o">==</span> <span class="s">&#34;&#34;</span> <span class="p">&#123;</span>
+			<span class="k">return</span> <span class="nx">User</span><span class="p">&#123;</span><span class="p">&#125;</span><span class="p">,</span> <span class="nx">errors</span><span class="p">.</span><span class="nf">New</span><span class="p">(</span><span class="s">&#34;name required&#34;</span><span class="p">)</span>
+		<span class="p">&#125;</span>
+		<span class="k">return</span> <span class="nx">u</span><span class="p">,</span> <span class="kc">nil</span>
+	<span class="p">&#125;</span><span class="p">)</span><span class="p">,</span>
+	<span class="kd">func</span><span class="p">(</span><span class="nx">c</span> <span class="nx">MyContext</span><span class="p">)</span> <span class="kt">error</span> <span class="p">&#123;</span>
+		<span class="c1">// typed body is stored under TargetJson</span>
+		<span class="nx">u</span><span class="p">,</span> <span class="nx">_</span> <span class="o">:=</span> <span class="nx">validator</span><span class="p">.</span><span class="nx">Valid</span><span class="p">[</span><span class="nx">User</span><span class="p">]</span><span class="p">(</span><span class="nx">c</span><span class="p">,</span> <span class="nx">validator</span><span class="p">.</span><span class="nx">TargetJson</span><span class="p">)</span>
+		<span class="k">return</span> <span class="nx">c</span><span class="p">.</span><span class="nf">Status</span><span class="p">(</span><span class="mi">201</span><span class="p">)</span><span class="p">.</span><span class="nf">Json</span><span class="p">(</span><span class="nx">u</span><span class="p">)</span>
+	<span class="p">&#125;</span><span class="p">,</span>
+<span class="p">)</span></code></pre>
+		`,
+	)
+}

--- a/docs/templates/layouts/layout.templ
+++ b/docs/templates/layouts/layout.templ
@@ -39,12 +39,13 @@ templ Layout(title string, active string, content templ.Component) {
 							<a href="/docs/routing" class={ "sidebar-link", templ.KV("active", active == "routing") }>Routing</a>
 							<a href="/docs/sub-routing" class={ "sidebar-link", templ.KV("active", active == "sub-routing") }>Sub-Routing</a>
 						</details>
-						<details class="sidebar-details" open?={ inSection(active, "middleware", "redirect", "error-handling", "request-body", "cookie") }>
+						<details class="sidebar-details" open?={ inSection(active, "middleware", "redirect", "error-handling", "request-body", "validator", "cookie") }>
 							<summary class={ styles.SidebarSectionTitle(), "sidebar-section-summary" }>Features</summary>
 							<a href="/docs/middleware" class={ "sidebar-link", templ.KV("active", active == "middleware") }>Middleware</a>
 							<a href="/docs/redirect" class={ "sidebar-link", templ.KV("active", active == "redirect") }>Redirect</a>
 							<a href="/docs/error-handling" class={ "sidebar-link", templ.KV("active", active == "error-handling") }>Error Handling</a>
 							<a href="/docs/request-body" class={ "sidebar-link", templ.KV("active", active == "request-body") }>Request Body</a>
+							<a href="/docs/validator" class={ "sidebar-link", templ.KV("active", active == "validator") }>Validator</a>
 							<a href="/docs/cookie" class={ "sidebar-link", templ.KV("active", active == "cookie") }>Cookie</a>
 						</details>
 						<details class="sidebar-details" open?={ inSection(active, "factory", "testing", "blow") }>

--- a/docs/templates/pages/validator.templ
+++ b/docs/templates/pages/validator.templ
@@ -1,0 +1,68 @@
+package pages
+
+import "github.com/poteto0/takibi-docs/templates/styles"
+import "github.com/poteto0/takibi-docs/templates/code"
+
+templ Validator() {
+	<h1>Validator</h1>
+	<p class={ styles.Lead() }>The <code>validator</code> package provides type-safe handlers that parse a request, validate it, and store the result in the context for the next handler to read. Validators are just regular handlers, so you place them before your route handler.</p>
+	<h2>Basic Usage</h2>
+	<p>A validator factory (<code>Form</code>, <code>Json</code>, <code>Query</code>, <code>Unmarshall</code>, <code>FormFile</code>) takes a function that receives the parsed input and returns the value you want to expose. That value is stored under a target key and retrieved later with <code>validator.Valid[T]</code>:</p>
+	@code.Validatorbasicgo()
+	<div class={ styles.Callout() }>
+		<code>validator.Valid[T]</code> returns <code>(T, ok)</code>. Once a validator has run successfully the value is always present, so the happy path can safely ignore <code>ok</code> with <code>_</code>. The <code>ok</code> guard exists to catch a wrong type parameter or target key.
+	</div>
+	<h2>Reporting Validation Errors</h2>
+	<p>There are two ways to reject a request, and you can mix them within one validator:</p>
+	<ul>
+		<li><strong>Inline + <code>ErrStop</code></strong> — write the response yourself and return <code>validator.ErrStop</code>. The chain halts and the error handler is <em>not</em> invoked.</li>
+		<li><strong>Return a normal <code>error</code></strong> — it flows to <code>app.OnError</code>, letting you render every validation failure in one central place. This is usually the more convenient default.</li>
+	</ul>
+	@code.Validatorerrorgo()
+	<h2>Typed JSON Bodies</h2>
+	<p><code>Unmarshall</code> decodes the JSON body straight into your struct, so the validator function receives a fully typed value instead of a <code>map</code>. The result is stored under <code>TargetJson</code>:</p>
+	@code.Validatorunmarshallgo()
+	<h2>File Uploads</h2>
+	<p><code>FormFile</code> parses a <code>multipart/form-data</code> body and hands your function the parsed <code>*multipart.Form</code>, where <code>form.Value</code> holds the text fields and <code>form.File</code> holds the uploaded files. The result is stored under <code>TargetFormFile</code>:</p>
+	@code.Validatorformfilego()
+	<div class={ styles.Callout() }>
+		The multipart form is parsed entirely in memory, so <code>FormFile</code> behaves identically on native and Cloudflare Workers (wasm) builds — the wasm runtime has no filesystem to spill large uploads to.
+	</div>
+	<h2>Target Keys</h2>
+	<table>
+		<thead>
+			<tr>
+				<th>Factory</th>
+				<th>Input passed to fn</th>
+				<th>Target key</th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr>
+				<td><code>validator.Form</code></td>
+				<td><code>url.Values</code></td>
+				<td><code>TargetForm</code> ("form")</td>
+			</tr>
+			<tr>
+				<td><code>validator.FormFile</code></td>
+				<td><code>*multipart.Form</code></td>
+				<td><code>TargetFormFile</code> ("formFile")</td>
+			</tr>
+			<tr>
+				<td><code>validator.Json</code></td>
+				<td><code>map[string]any</code></td>
+				<td><code>TargetJson</code> ("json")</td>
+			</tr>
+			<tr>
+				<td><code>validator.Unmarshall</code></td>
+				<td><code>T</code> (decoded struct)</td>
+				<td><code>TargetJson</code> ("json")</td>
+			</tr>
+			<tr>
+				<td><code>validator.Query</code></td>
+				<td><code>map[string]string</code></td>
+				<td><code>TargetQuery</code> ("query")</td>
+			</tr>
+		</tbody>
+	</table>
+}

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -1,6 +1,7 @@
 package validator
 
 import (
+	"mime/multipart"
 	"net/url"
 
 	"github.com/poteto0/takibi/constants"
@@ -14,10 +15,16 @@ var ErrStop = constants.ErrStop
 
 // Target keys used by the built-in validator factories.
 const (
-	TargetForm  = "form"
-	TargetJson  = "json"
-	TargetQuery = "query"
+	TargetForm     = "form"
+	TargetFormFile = "formFile"
+	TargetJson     = "json"
+	TargetQuery    = "query"
 )
+
+// formFileMaxMemory is the in-memory threshold for ParseMultipartForm. Setting
+// it to the default body limit keeps the whole form in memory instead of
+// spilling to temp files, so FormFile behaves the same on wasm (no filesystem).
+const formFileMaxMemory = constants.DefaultMaxBodyBytes
 
 func newValidator[Bindings any, In any, T any](
 	key string,
@@ -48,6 +55,24 @@ func Form[Bindings any, T any](
 			return nil, err
 		}
 		return c.Req().Raw().Form, nil
+	}, fn)
+}
+
+// FormFile returns a HandlerFunc that parses a multipart/form-data request body
+// and passes the parsed *multipart.Form (both Value and File maps) to fn. The
+// returned value is stored under TargetFormFile ("formFile").
+//
+// The form is parsed entirely in memory (see formFileMaxMemory) so behaviour is
+// identical on native and wasm builds.
+func FormFile[Bindings any, T any](
+	fn func(*multipart.Form, interfaces.IContext[Bindings]) (T, error),
+) interfaces.HandlerFunc[Bindings] {
+	return newValidator(TargetFormFile, func(c interfaces.IContext[Bindings]) (*multipart.Form, error) {
+		raw := c.Req().Raw()
+		if err := raw.ParseMultipartForm(formFileMaxMemory); err != nil {
+			return nil, err
+		}
+		return raw.MultipartForm, nil
 	}, fn)
 }
 

--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -1,7 +1,10 @@
 package validator_test
 
 import (
+	"bytes"
 	"errors"
+	"io"
+	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -274,6 +277,144 @@ func TestUnmarshall_DecodeErrorReachesErrorHandler(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodPost, "/users", strings.NewReader(`{invalid json`))
 	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	app.ServeHTTP(w, req)
+
+	assert.True(t, called)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+type Upload struct {
+	Title    string
+	Filename string
+	Content  string
+}
+
+// buildMultipart creates a multipart/form-data body with one value field and
+// one file field, returning the body and its Content-Type header.
+func buildMultipart(t *testing.T, field, value, fileField, filename, content string) (*bytes.Buffer, string) {
+	t.Helper()
+	body := &bytes.Buffer{}
+	w := multipart.NewWriter(body)
+	if err := w.WriteField(field, value); err != nil {
+		t.Fatal(err)
+	}
+	fw, err := w.CreateFormFile(fileField, filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := fw.Write([]byte(content)); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return body, w.FormDataContentType()
+}
+
+func TestFormFile_StoresValidatedData(t *testing.T) {
+	called := false
+
+	app := takibi.New(&Bindings{})
+	app.Post("/upload",
+		validator.FormFile(func(form *multipart.Form, c MyContext) (Upload, error) {
+			fhs := form.File["avatar"]
+			if len(fhs) == 0 {
+				c.Status(http.StatusUnprocessableEntity).Text("avatar required")
+				return Upload{}, validator.ErrStop
+			}
+			f, err := fhs[0].Open()
+			if err != nil {
+				return Upload{}, err
+			}
+			defer f.Close()
+			content, err := io.ReadAll(f)
+			if err != nil {
+				return Upload{}, err
+			}
+			return Upload{
+				Title:    form.Value["title"][0],
+				Filename: fhs[0].Filename,
+				Content:  string(content),
+			}, nil
+		}),
+		func(c MyContext) error {
+			called = true
+			up, ok := validator.Valid[Upload](c, validator.TargetFormFile)
+			assert.True(t, ok)
+			assert.Equal(t, "hello", up.Title)
+			assert.Equal(t, "a.txt", up.Filename)
+			assert.Equal(t, "file-body", up.Content)
+			return c.Status(http.StatusCreated).Text("created")
+		},
+	)
+
+	body, contentType := buildMultipart(t, "title", "hello", "avatar", "a.txt", "file-body")
+	req := httptest.NewRequest(http.MethodPost, "/upload", body)
+	req.Header.Set("Content-Type", contentType)
+	w := httptest.NewRecorder()
+
+	app.ServeHTTP(w, req)
+
+	assert.True(t, called)
+	assert.Equal(t, http.StatusCreated, w.Code)
+}
+
+func TestFormFile_ErrStopHaltsChain(t *testing.T) {
+	nextCalled := false
+
+	app := takibi.New(&Bindings{})
+	app.Post("/upload",
+		validator.FormFile(func(form *multipart.Form, c MyContext) (Upload, error) {
+			if len(form.File["avatar"]) == 0 {
+				c.Status(http.StatusUnprocessableEntity).Text("avatar required")
+				return Upload{}, validator.ErrStop
+			}
+			return Upload{}, nil
+		}),
+		func(c MyContext) error {
+			nextCalled = true
+			return c.Status(http.StatusCreated).Text("created")
+		},
+	)
+
+	// multipart body with no file field
+	body := &bytes.Buffer{}
+	mw := multipart.NewWriter(body)
+	_ = mw.WriteField("title", "x")
+	_ = mw.Close()
+	req := httptest.NewRequest(http.MethodPost, "/upload", body)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	w := httptest.NewRecorder()
+
+	app.ServeHTTP(w, req)
+
+	assert.False(t, nextCalled)
+	assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
+	assert.Equal(t, "avatar required", w.Body.String())
+}
+
+func TestFormFile_ParseErrorReachesErrorHandler(t *testing.T) {
+	called := false
+
+	app := takibi.New(&Bindings{})
+	app.OnError(func(c MyContext, err error) error {
+		called = true
+		return c.Status(http.StatusBadRequest).Text("parse failed")
+	})
+	app.Post("/upload",
+		validator.FormFile(func(form *multipart.Form, c MyContext) (Upload, error) {
+			return Upload{}, nil
+		}),
+		func(c MyContext) error {
+			return c.Text("unreachable")
+		},
+	)
+
+	// Declares multipart but body is not a valid multipart payload.
+	req := httptest.NewRequest(http.MethodPost, "/upload", strings.NewReader("not-multipart"))
+	req.Header.Set("Content-Type", "multipart/form-data; boundary=xxx")
 	w := httptest.NewRecorder()
 
 	app.ServeHTTP(w, req)


### PR DESCRIPTION
## What

Add a `FormFile` validator factory for `multipart/form-data` request bodies, plus a dedicated `/docs/validator` documentation page.

### `validator.FormFile`

```go
app.Post("/upload",
    validator.FormFile(func(form *multipart.Form, c MyContext) (Upload, error) {
        files := form.File["avatar"]
        if len(files) == 0 {
            c.Status(422).Text("avatar required")
            return Upload{}, validator.ErrStop
        }
        // form.Value -> text fields, form.File -> uploaded files
        return Upload{Filename: files[0].Filename}, nil
    }),
    func(c MyContext) error {
        up, _ := validator.Valid[Upload](c, validator.TargetFormFile)
        return c.Status(201).Text(up.Filename)
    },
)
```

- Passes the parsed `*multipart.Form` (both `Value` and `File`) to the validation fn.
- Result stored under the new `TargetFormFile` (`"formFile"`) key.
- Follows the existing factory pattern (`Form`/`Json`/`Query`/`Unmarshall`) built on `newValidator`, so the `ErrStop` (inline response) and plain-`error` (→ `OnError`) patterns both work unchanged.

### wasm parity

`validator/` and `thttp/request.go` are build-tag-free shared code operating on the standard `*http.Request`, so `FormFile` works identically on native and Cloudflare Workers (wasm). The form is parsed fully in memory (`formFileMaxMemory = DefaultMaxBodyBytes`) to avoid temp-file spill, since the wasm runtime has no real filesystem.

### Docs

New `/docs/validator` page covering all validator factories, the `ErrStop` vs error-return patterns, file uploads, and a target-key reference. Registered in `docs/main.go` and the sidebar.

## Testing

- TDD: 3 new tests (stores validated data / `ErrStop` halts chain / parse error reaches `OnError`).
- `go test ./...` green, **validator package at 100% coverage**.
- `GOOS=js GOARCH=wasm go build ./...` passes; docs module builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
