### PR TITLE
feat(validator): add File/FileField multipart file validators

### DIFF
--- a/docs/templates/code/validatorfilefieldgo.templ
+++ b/docs/templates/code/validatorfilefieldgo.templ
@@ -1,0 +1,35 @@
+package code
+
+templ Validatorfilefieldgo() {
+	@templ.Raw(
+		`
+			<pre class="chroma"><code><span class="nx">app</span><span class="p">.</span><span class="nf">Post</span><span class="p">(</span><span class="s">&#34;/cats/:id/avatar&#34;</span><span class="p">,</span>
+	<span class="c1">// Validate the &#34;avatar&#34; file part: required, at most 5 MiB, and an image.</span>
+	<span class="c1">// AllowedTypes is checked against the *sniffed* content type (the first 512</span>
+	<span class="c1">// bytes), not the client-declared Content-Type header, so it can&#39;t be spoofed.</span>
+	<span class="nx">validator</span><span class="p">.</span><span class="nx">FileField</span><span class="p">[</span><span class="nx">Bindings</span><span class="p">]</span><span class="p">(</span><span class="nx">validator</span><span class="p">.</span><span class="nx">FileConstraint</span><span class="p">&#123;</span>
+		<span class="nx">Field</span><span class="p">:</span>        <span class="s">&#34;avatar&#34;</span><span class="p">,</span>
+		<span class="nx">Required</span><span class="p">:</span>     <span class="kc">true</span><span class="p">,</span>
+		<span class="nx">MaxBytes</span><span class="p">:</span>     <span class="mi">5</span> <span class="o">&lt;&lt;</span> <span class="mi">20</span><span class="p">,</span>
+		<span class="nx">AllowedTypes</span><span class="p">:</span> <span class="p">[</span><span class="p">]</span><span class="kt">string</span><span class="p">&#123;</span><span class="s">&#34;image/png&#34;</span><span class="p">,</span> <span class="s">&#34;image/jpeg&#34;</span><span class="p">,</span> <span class="s">&#34;image/webp&#34;</span><span class="p">&#125;</span><span class="p">,</span>
+	<span class="p">&#125;</span><span class="p">)</span><span class="p">,</span>
+	<span class="kd">func</span><span class="p">(</span><span class="nx">c</span> <span class="nx">MyContext</span><span class="p">)</span> <span class="kt">error</span> <span class="p">&#123;</span>
+		<span class="nx">file</span><span class="p">,</span> <span class="nx">_</span> <span class="o">:=</span> <span class="nx">validator</span><span class="p">.</span><span class="nx">Valid</span><span class="p">[</span><span class="nx">validator</span><span class="p">.</span><span class="nx">UploadedFile</span><span class="p">]</span><span class="p">(</span><span class="nx">c</span><span class="p">,</span> <span class="nx">validator</span><span class="p">.</span><span class="nx">TargetFormFile</span><span class="p">)</span>
+
+		<span class="c1">// Stream the file straight to storage — no need to read it into memory.</span>
+		<span class="nx">f</span><span class="p">,</span> <span class="nx">err</span> <span class="o">:=</span> <span class="nx">file</span><span class="p">.</span><span class="nf">Open</span><span class="p">(</span><span class="p">)</span>
+		<span class="k">if</span> <span class="nx">err</span> <span class="o">!=</span> <span class="kc">nil</span> <span class="p">&#123;</span>
+			<span class="k">return</span> <span class="nx">err</span>
+		<span class="p">&#125;</span>
+		<span class="k">defer</span> <span class="nx">f</span><span class="p">.</span><span class="nf">Close</span><span class="p">(</span><span class="p">)</span>
+
+		<span class="nx">key</span> <span class="o">:=</span> <span class="nx">uuid</span><span class="p">.</span><span class="nf">NewString</span><span class="p">(</span><span class="p">)</span>
+		<span class="k">if</span> <span class="nx">_</span><span class="p">,</span> <span class="nx">err</span> <span class="o">:=</span> <span class="nx">blob</span><span class="p">.</span><span class="nf">UploadImage</span><span class="p">(</span><span class="nx">c</span><span class="p">.</span><span class="nf">Env</span><span class="p">(</span><span class="p">)</span><span class="p">.</span><span class="nx">BUCKET</span><span class="p">,</span> <span class="nx">key</span><span class="p">,</span> <span class="nx">f</span><span class="p">,</span> <span class="nx">file</span><span class="p">.</span><span class="nx">ContentType</span><span class="p">)</span><span class="p">;</span> <span class="nx">err</span> <span class="o">!=</span> <span class="kc">nil</span> <span class="p">&#123;</span>
+			<span class="k">return</span> <span class="nx">err</span>
+		<span class="p">&#125;</span>
+		<span class="k">return</span> <span class="nx">c</span><span class="p">.</span><span class="nf">Status</span><span class="p">(</span><span class="mi">201</span><span class="p">)</span><span class="p">.</span><span class="nf">Json</span><span class="p">(</span><span class="kd">map</span><span class="p">[</span><span class="kt">string</span><span class="p">]</span><span class="kt">string</span><span class="p">&#123;</span><span class="s">&#34;status&#34;</span><span class="p">:</span> <span class="s">&#34;updated&#34;</span><span class="p">&#125;</span><span class="p">)</span>
+	<span class="p">&#125;</span><span class="p">,</span>
+<span class="p">)</span></code></pre>
+		`,
+	)
+}

--- a/docs/templates/pages/validator.templ
+++ b/docs/templates/pages/validator.templ
@@ -34,6 +34,12 @@ templ Validator() {
 	<div class={ styles.Callout() }>
 		The multipart form is parsed entirely in memory, so <code>FormFile</code> behaves identically on native and Cloudflare Workers (wasm) builds — the wasm runtime has no filesystem to spill large uploads to.
 	</div>
+	<h2>Validated File Uploads</h2>
+	<p><code>FileField</code> builds on <code>FormFile</code> to cover the common case of accepting a single file under known constraints. You declare a <code>FileConstraint</code> (field name, <code>Required</code>, <code>MaxBytes</code>, <code>AllowedTypes</code>) and it runs the required / size / content-type checks on your behalf, storing a validated <code>UploadedFile</code> under <code>TargetFormFile</code>. The handler keeps only the domain logic — open the file and stream it on:</p>
+	@code.Validatorfilefieldgo()
+	<div class={ styles.Callout() }>
+		<code>AllowedTypes</code> is matched against the content type <em>sniffed</em> from the file's leading bytes (via <code>http.DetectContentType</code>), not the client-supplied <code>Content-Type</code> header, so a renamed or mislabelled upload is still rejected. A constraint violation returns a <code>*validator.FileError</code> (with <code>Field</code> and <code>Reason</code>: <code>FileErrRequired</code>, <code>FileErrTooLarge</code>, or <code>FileErrUnsupportedType</code>) which flows to <code>app.OnError</code> — render it however your API formats errors. Use <code>validator.File</code> (the <code>fn</code> form) when you also need the form's text fields alongside the file.
+	</div>
 	<h2>Target Keys</h2>
 	<table>
 		<thead>
@@ -52,6 +58,16 @@ templ Validator() {
 			<tr>
 				<td><code>validator.FormFile</code></td>
 				<td><code>*multipart.Form</code></td>
+				<td><code>TargetFormFile</code> ("formFile")</td>
+			</tr>
+			<tr>
+				<td><code>validator.File</code></td>
+				<td><code>UploadedFile</code>, <code>*multipart.Form</code></td>
+				<td><code>TargetFormFile</code> ("formFile")</td>
+			</tr>
+			<tr>
+				<td><code>validator.FileField</code></td>
+				<td>— (stores <code>UploadedFile</code>)</td>
 				<td><code>TargetFormFile</code> ("formFile")</td>
 			</tr>
 			<tr>

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -1,8 +1,13 @@
 package validator
 
 import (
+	"fmt"
+	"io"
+	"mime"
 	"mime/multipart"
+	"net/http"
 	"net/url"
+	"slices"
 
 	"github.com/poteto0/takibi/constants"
 	"github.com/poteto0/takibi/interfaces"
@@ -74,6 +79,159 @@ func FormFile[Bindings any, T any](
 		}
 		return raw.MultipartForm, nil
 	}, fn)
+}
+
+// Reasons reported by FileError.
+const (
+	FileErrRequired        = "required"
+	FileErrTooLarge        = "too_large"
+	FileErrUnsupportedType = "unsupported_type"
+)
+
+// sniffLen is the number of leading bytes http.DetectContentType inspects.
+const sniffLen = 512
+
+// FileConstraint declares the validation rules applied to a single uploaded
+// file field by File and FileField.
+type FileConstraint struct {
+	Field        string   // multipart field name (required)
+	Required     bool     // reject when the field carries no file part
+	MaxBytes     int64    // reject files larger than this; 0 disables the check
+	AllowedTypes []string // permitted (sniffed) Content-Types; empty allows any
+}
+
+// UploadedFile is a validated file part. The handler opens it via Open and is
+// responsible for closing the returned multipart.File.
+type UploadedFile struct {
+	Field       string
+	Filename    string
+	ContentType string // content type detected by sniffing the file's bytes
+	Size        int64
+	Header      *multipart.FileHeader
+}
+
+// Open opens the underlying multipart file for reading. The caller must Close
+// the returned file. It returns an error when the file is absent (zero value).
+func (u UploadedFile) Open() (multipart.File, error) {
+	if u.Header == nil {
+		return nil, fmt.Errorf("no file to open for field %q", u.Field)
+	}
+	return u.Header.Open()
+}
+
+// FileError is returned by File/FileField when an uploaded file violates a
+// FileConstraint. It flows to app.OnError so the application can render its own
+// error response. Reason is one of the FileErr* constants.
+type FileError struct {
+	Field  string
+	Reason string
+}
+
+func (e *FileError) Error() string {
+	return fmt.Sprintf("file %q: %s", e.Field, e.Reason)
+}
+
+// fileInput carries the validated file and the parsed form to the File fn.
+type fileInput struct {
+	file UploadedFile
+	form *multipart.Form
+}
+
+// File parses a multipart/form-data body, validates the file field named by c
+// against its constraints, then passes the validated UploadedFile and the full
+// *multipart.Form (for the text Value fields) to fn. The returned value is
+// stored under TargetFormFile ("formFile").
+//
+// A constraint violation returns a *FileError (flowing to app.OnError) rather
+// than writing a response, so the application controls the error format.
+func File[Bindings any, T any](
+	c FileConstraint,
+	fn func(UploadedFile, *multipart.Form, interfaces.IContext[Bindings]) (T, error),
+) interfaces.HandlerFunc[Bindings] {
+	return newValidator(TargetFormFile, func(ctx interfaces.IContext[Bindings]) (fileInput, error) {
+		raw := ctx.Req().Raw()
+		if err := raw.ParseMultipartForm(formFileMaxMemory); err != nil {
+			return fileInput{}, err
+		}
+		form := raw.MultipartForm
+		file, err := validateFile(form, c)
+		if err != nil {
+			return fileInput{}, err
+		}
+		return fileInput{file: file, form: form}, nil
+	}, func(in fileInput, ctx interfaces.IContext[Bindings]) (T, error) {
+		return fn(in.file, in.form, ctx)
+	})
+}
+
+// FileField is the no-fn shortcut over File: it validates the named file field
+// and stores the resulting UploadedFile under TargetFormFile ("formFile"),
+// ready to retrieve with Valid[UploadedFile]. Use File when you also need the
+// form's text fields.
+func FileField[Bindings any](c FileConstraint) interfaces.HandlerFunc[Bindings] {
+	return File(c, func(file UploadedFile, _ *multipart.Form, _ interfaces.IContext[Bindings]) (UploadedFile, error) {
+		return file, nil
+	})
+}
+
+// validateFile checks the file part named by c against its constraints. When
+// the field is optional and absent it returns the zero UploadedFile with no
+// error; a present file is validated for size and (sniffed) content type.
+func validateFile(form *multipart.Form, c FileConstraint) (UploadedFile, error) {
+	var headers []*multipart.FileHeader
+	if form != nil {
+		headers = form.File[c.Field]
+	}
+	if len(headers) == 0 {
+		if c.Required {
+			return UploadedFile{}, &FileError{Field: c.Field, Reason: FileErrRequired}
+		}
+		return UploadedFile{}, nil
+	}
+
+	fh := headers[0]
+	if c.MaxBytes > 0 && fh.Size > c.MaxBytes {
+		return UploadedFile{}, &FileError{Field: c.Field, Reason: FileErrTooLarge}
+	}
+
+	contentType, err := sniffContentType(fh)
+	if err != nil {
+		return UploadedFile{}, err
+	}
+	if len(c.AllowedTypes) > 0 && !slices.Contains(c.AllowedTypes, contentType) {
+		return UploadedFile{}, &FileError{Field: c.Field, Reason: FileErrUnsupportedType}
+	}
+
+	return UploadedFile{
+		Field:       c.Field,
+		Filename:    fh.Filename,
+		ContentType: contentType,
+		Size:        fh.Size,
+		Header:      fh,
+	}, nil
+}
+
+// sniffContentType detects the content type from the file's leading bytes
+// instead of trusting the client-declared Content-Type header. Any media-type
+// parameters (e.g. "; charset=utf-8") are stripped so the value compares
+// cleanly against FileConstraint.AllowedTypes.
+func sniffContentType(fh *multipart.FileHeader) (string, error) {
+	f, err := fh.Open()
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	buf := make([]byte, sniffLen)
+	n, err := io.ReadFull(f, buf)
+	if err != nil && err != io.EOF && err != io.ErrUnexpectedEOF {
+		return "", err
+	}
+	detected := http.DetectContentType(buf[:n])
+	if mediaType, _, err := mime.ParseMediaType(detected); err == nil {
+		return mediaType, nil
+	}
+	return detected, nil
 }
 
 // Json returns a HandlerFunc that reads the JSON request body and passes

--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -520,6 +520,201 @@ func TestFormFile_ParseErrorReachesErrorHandler(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
+// pngBytes returns a minimal byte slice whose signature makes
+// http.DetectContentType report "image/png".
+func pngBytes() string {
+	return string([]byte{0x89, 'P', 'N', 'G', 0x0d, 0x0a, 0x1a, 0x0a, 0, 0, 0, 0})
+}
+
+func TestFileField_StoresValidatedFile(t *testing.T) {
+	called := false
+
+	app := takibi.New(&Bindings{})
+	app.Post("/upload",
+		validator.FileField[Bindings](validator.FileConstraint{
+			Field:        "avatar",
+			Required:     true,
+			MaxBytes:     1 << 20,
+			AllowedTypes: []string{"image/png"},
+		}),
+		func(c MyContext) error {
+			called = true
+			file, ok := validator.Valid[validator.UploadedFile](c, validator.TargetFormFile)
+			assert.True(t, ok)
+			assert.Equal(t, "avatar", file.Field)
+			assert.Equal(t, "a.png", file.Filename)
+			assert.Equal(t, "image/png", file.ContentType)
+			assert.Equal(t, int64(len(pngBytes())), file.Size)
+
+			f, err := file.Open()
+			assert.NoError(t, err)
+			defer f.Close()
+			content, _ := io.ReadAll(f)
+			assert.Equal(t, pngBytes(), string(content))
+			return c.Status(http.StatusCreated).Text("created")
+		},
+	)
+
+	body, contentType := buildMultipart(t, "title", "hello", "avatar", "a.png", pngBytes())
+	req := httptest.NewRequest(http.MethodPost, "/upload", body)
+	req.Header.Set("Content-Type", contentType)
+	w := httptest.NewRecorder()
+
+	app.ServeHTTP(w, req)
+
+	assert.True(t, called)
+	assert.Equal(t, http.StatusCreated, w.Code)
+}
+
+func TestFileField_RequiredMissing_ReturnsFileError(t *testing.T) {
+	var captured error
+
+	app := takibi.New(&Bindings{})
+	app.OnError(func(c MyContext, err error) error {
+		captured = err
+		return c.Status(http.StatusUnprocessableEntity).Text("err")
+	})
+	app.Post("/upload",
+		validator.FileField[Bindings](validator.FileConstraint{Field: "avatar", Required: true}),
+		func(c MyContext) error { return c.Text("unreachable") },
+	)
+
+	// multipart body with no file field
+	body := &bytes.Buffer{}
+	mw := multipart.NewWriter(body)
+	_ = mw.WriteField("title", "x")
+	_ = mw.Close()
+	req := httptest.NewRequest(http.MethodPost, "/upload", body)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	w := httptest.NewRecorder()
+
+	app.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
+	var fe *validator.FileError
+	assert.True(t, errors.As(captured, &fe))
+	assert.Equal(t, "avatar", fe.Field)
+	assert.Equal(t, validator.FileErrRequired, fe.Reason)
+}
+
+func TestFileField_TooLarge_ReturnsFileError(t *testing.T) {
+	var captured error
+
+	app := takibi.New(&Bindings{})
+	app.OnError(func(c MyContext, err error) error {
+		captured = err
+		return c.Status(http.StatusRequestEntityTooLarge).Text("err")
+	})
+	app.Post("/upload",
+		validator.FileField[Bindings](validator.FileConstraint{Field: "avatar", MaxBytes: 4}),
+		func(c MyContext) error { return c.Text("unreachable") },
+	)
+
+	body, contentType := buildMultipart(t, "title", "x", "avatar", "a.png", pngBytes())
+	req := httptest.NewRequest(http.MethodPost, "/upload", body)
+	req.Header.Set("Content-Type", contentType)
+	w := httptest.NewRecorder()
+
+	app.ServeHTTP(w, req)
+
+	var fe *validator.FileError
+	assert.True(t, errors.As(captured, &fe))
+	assert.Equal(t, validator.FileErrTooLarge, fe.Reason)
+}
+
+func TestFileField_UnsupportedType_ReturnsFileError(t *testing.T) {
+	var captured error
+
+	app := takibi.New(&Bindings{})
+	app.OnError(func(c MyContext, err error) error {
+		captured = err
+		return c.Status(http.StatusUnsupportedMediaType).Text("err")
+	})
+	app.Post("/upload",
+		validator.FileField[Bindings](validator.FileConstraint{
+			Field:        "avatar",
+			AllowedTypes: []string{"image/png"},
+		}),
+		func(c MyContext) error { return c.Text("unreachable") },
+	)
+
+	// plain text content sniffs to text/plain, not image/png — even though the
+	// client declares it as image/png the validator rejects it.
+	body, contentType := buildMultipart(t, "title", "x", "avatar", "a.png", "just text content")
+	req := httptest.NewRequest(http.MethodPost, "/upload", body)
+	req.Header.Set("Content-Type", contentType)
+	w := httptest.NewRecorder()
+
+	app.ServeHTTP(w, req)
+
+	var fe *validator.FileError
+	assert.True(t, errors.As(captured, &fe))
+	assert.Equal(t, validator.FileErrUnsupportedType, fe.Reason)
+}
+
+func TestFileField_OptionalAbsent_StoresZeroValue(t *testing.T) {
+	called := false
+
+	app := takibi.New(&Bindings{})
+	app.Post("/upload",
+		validator.FileField[Bindings](validator.FileConstraint{Field: "avatar"}),
+		func(c MyContext) error {
+			called = true
+			file, ok := validator.Valid[validator.UploadedFile](c, validator.TargetFormFile)
+			assert.True(t, ok)
+			assert.Equal(t, validator.UploadedFile{}, file)
+			return c.Status(http.StatusOK).Text("ok")
+		},
+	)
+
+	body := &bytes.Buffer{}
+	mw := multipart.NewWriter(body)
+	_ = mw.WriteField("title", "x")
+	_ = mw.Close()
+	req := httptest.NewRequest(http.MethodPost, "/upload", body)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	w := httptest.NewRecorder()
+
+	app.ServeHTTP(w, req)
+
+	assert.True(t, called)
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestFile_CombinesFileAndTextFields(t *testing.T) {
+	type Avatar struct {
+		Title    string
+		Filename string
+	}
+	called := false
+
+	app := takibi.New(&Bindings{})
+	app.Post("/upload",
+		validator.File(validator.FileConstraint{Field: "avatar", Required: true},
+			func(file validator.UploadedFile, form *multipart.Form, c MyContext) (Avatar, error) {
+				return Avatar{Title: form.Value["title"][0], Filename: file.Filename}, nil
+			}),
+		func(c MyContext) error {
+			called = true
+			a, ok := validator.Valid[Avatar](c, validator.TargetFormFile)
+			assert.True(t, ok)
+			assert.Equal(t, "hello", a.Title)
+			assert.Equal(t, "a.png", a.Filename)
+			return c.Status(http.StatusCreated).Text("created")
+		},
+	)
+
+	body, contentType := buildMultipart(t, "title", "hello", "avatar", "a.png", pngBytes())
+	req := httptest.NewRequest(http.MethodPost, "/upload", body)
+	req.Header.Set("Content-Type", contentType)
+	w := httptest.NewRecorder()
+
+	app.ServeHTTP(w, req)
+
+	assert.True(t, called)
+	assert.Equal(t, http.StatusCreated, w.Code)
+}
+
 func TestValid_ReturnsZeroWhenMissing(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	w := httptest.NewRecorder()


### PR DESCRIPTION
## Why

The existing `validator.FormFile` only hands back a raw `*multipart.Form`, so every file-upload handler re-implements the same boilerplate: pull `form.File["x"]`, check it's present, enforce a size limit, check the content type, then `Open()`. Real handlers (e.g. a cat-avatar upload that streams to blob storage and updates the DB) end up mixing that validation plumbing with domain logic.

This PR adds a constraint-driven layer on top of `FormFile` so the framework owns the required / size / content-type checks and the handler keeps only the domain work.

## What

- **`FileConstraint`** — declares the rules: `Field`, `Required`, `MaxBytes`, `AllowedTypes`.
- **`FileField[Bindings](c)`** — validates a single file field and stores the resulting `UploadedFile` under `TargetFormFile`. No `fn` needed.
- **`File[Bindings, T](c, fn)`** — same validation, but also passes the full `*multipart.Form` so you can combine the file with text fields into a typed `T`.
- **`UploadedFile`** — `Field`, `Filename`, `ContentType`, `Size`, `Header`, plus `Open()` to stream the file (caller closes).
- **`FileError{Field, Reason}`** — returned on a violation and flows to `app.OnError`, so the app renders its own error shape (`FileErrRequired`, `FileErrTooLarge`, `FileErrUnsupportedType`).

### Security note

`AllowedTypes` is matched against the content type **sniffed** from the first 512 bytes via `http.DetectContentType`, not the client-declared `Content-Type` header — a renamed/mislabelled upload is still rejected. Parsing stays fully in memory, so behaviour is identical on native and Cloudflare Workers (wasm).

## Usage

```go
app.Post("/cats/:id/avatar",
	validator.FileField[Bindings](validator.FileConstraint{
		Field:        "avatar",
		Required:     true,
		MaxBytes:     5 << 20, // 5 MiB
		AllowedTypes: []string{"image/png", "image/jpeg", "image/webp"},
	}),
	func(c MyContext) error {
		file, _ := validator.Valid[validator.UploadedFile](c, validator.TargetFormFile)

		f, err := file.Open()
		if err != nil {
			return err
		}
		defer f.Close()

		key := uuid.NewString()
		if _, err := blob.UploadImage(c.Env().BUCKET, key, f, file.ContentType); err != nil {
			return err
		}
		return c.Status(201).Json(map[string]string{"status": "updated"})
	},
)
```

Combining the file with text fields:

```go
validator.File(validator.FileConstraint{Field: "avatar", Required: true},
	func(file validator.UploadedFile, form *multipart.Form, c MyContext) (Avatar, error) {
		return Avatar{Title: form.Value["title"][0], Filename: file.Filename}, nil
	})
```

Rendering the error centrally:

```go
app.OnError(func(c MyContext, err error) error {
	var fe *validator.FileError
	if errors.As(err, &fe) {
		return c.Status(422).Json(map[string]string{"field": fe.Field, "reason": fe.Reason})
	}
	return c.Status(500).Text("internal error")
})
```

## Tests

Added TDD coverage in `validator/validator_test.go`: valid upload (with sniffed content type), required-missing, too-large, unsupported-type, optional-absent, and the `File` combine-with-text-fields case. Full suite green.

## Docs

New "Validated File Uploads" section in `docs/templates/pages/validator.templ` (snippet asset `validatorfilefieldgo`) plus `validator.File` / `validator.FileField` rows in the target-key table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)