### PR TITLE
feat(validator): make File/FileField error handling customizable

### DIFF
--- a/docs/templates/code/validatorfileerrorgo.templ
+++ b/docs/templates/code/validatorfileerrorgo.templ
@@ -1,0 +1,35 @@
+package code
+
+templ Validatorfileerrorgo() {
+	@templ.Raw(
+		`
+			<pre class="chroma"><code><span class="nx">app</span><span class="p">.</span><span class="nf">Post</span><span class="p">(</span><span class="s">&#34;/cats/:id/avatar&#34;</span><span class="p">,</span>
+	<span class="nx">validator</span><span class="p">.</span><span class="nx">FileField</span><span class="p">[</span><span class="nx">Bindings</span><span class="p">]</span><span class="p">(</span>
+		<span class="nx">validator</span><span class="p">.</span><span class="nx">FileConstraint</span><span class="p">&#123;</span>
+			<span class="nx">Field</span><span class="p">:</span>        <span class="s">&#34;avatar&#34;</span><span class="p">,</span>
+			<span class="nx">Required</span><span class="p">:</span>     <span class="kc">true</span><span class="p">,</span>
+			<span class="nx">MaxBytes</span><span class="p">:</span>     <span class="mi">5</span> <span class="o">&lt;&lt;</span> <span class="mi">20</span><span class="p">,</span>
+			<span class="nx">AllowedTypes</span><span class="p">:</span> <span class="p">[</span><span class="p">]</span><span class="kt">string</span><span class="p">&#123;</span><span class="s">&#34;image/png&#34;</span><span class="p">,</span> <span class="s">&#34;image/jpeg&#34;</span><span class="p">&#125;</span><span class="p">,</span>
+		<span class="p">&#125;</span><span class="p">,</span>
+		<span class="c1">// Override the default *FileError handling. The handler receives the</span>
+		<span class="c1">// violation and the context, so you can render the response yourself.</span>
+		<span class="nx">validator</span><span class="p">.</span><span class="nf">WithFileError</span><span class="p">(</span><span class="kd">func</span><span class="p">(</span><span class="nx">fe</span> <span class="o">*</span><span class="nx">validator</span><span class="p">.</span><span class="nx">FileError</span><span class="p">,</span> <span class="nx">c</span> <span class="nx">MyContext</span><span class="p">)</span> <span class="kt">error</span> <span class="p">&#123;</span>
+			<span class="nx">status</span> <span class="o">:=</span> <span class="nx">http</span><span class="p">.</span><span class="nx">StatusUnprocessableEntity</span>
+			<span class="k">if</span> <span class="nx">fe</span><span class="p">.</span><span class="nx">Reason</span> <span class="o">==</span> <span class="nx">validator</span><span class="p">.</span><span class="nx">FileErrTooLarge</span> <span class="p">&#123;</span>
+				<span class="nx">status</span> <span class="p">=</span> <span class="nx">http</span><span class="p">.</span><span class="nx">StatusRequestEntityTooLarge</span>
+			<span class="p">&#125;</span>
+			<span class="nx">c</span><span class="p">.</span><span class="nf">Status</span><span class="p">(</span><span class="nx">status</span><span class="p">)</span><span class="p">.</span><span class="nf">Json</span><span class="p">(</span><span class="kd">map</span><span class="p">[</span><span class="kt">string</span><span class="p">]</span><span class="kt">string</span><span class="p">&#123;</span>
+				<span class="s">&#34;field&#34;</span><span class="p">:</span>  <span class="nx">fe</span><span class="p">.</span><span class="nx">Field</span><span class="p">,</span>
+				<span class="s">&#34;reason&#34;</span><span class="p">:</span> <span class="nx">fe</span><span class="p">.</span><span class="nx">Reason</span><span class="p">,</span>
+			<span class="p">&#125;</span><span class="p">)</span>
+			<span class="k">return</span> <span class="nx">validator</span><span class="p">.</span><span class="nx">ErrStop</span> <span class="c1">// response already written; halt the chain</span>
+		<span class="p">&#125;</span><span class="p">)</span><span class="p">,</span>
+	<span class="p">)</span><span class="p">,</span>
+	<span class="kd">func</span><span class="p">(</span><span class="nx">c</span> <span class="nx">MyContext</span><span class="p">)</span> <span class="kt">error</span> <span class="p">&#123;</span>
+		<span class="nx">file</span><span class="p">,</span> <span class="nx">_</span> <span class="o">:=</span> <span class="nx">validator</span><span class="p">.</span><span class="nx">Valid</span><span class="p">[</span><span class="nx">validator</span><span class="p">.</span><span class="nx">UploadedFile</span><span class="p">]</span><span class="p">(</span><span class="nx">c</span><span class="p">,</span> <span class="nx">validator</span><span class="p">.</span><span class="nx">TargetFormFile</span><span class="p">)</span>
+		<span class="k">return</span> <span class="nx">c</span><span class="p">.</span><span class="nf">Status</span><span class="p">(</span><span class="mi">201</span><span class="p">)</span><span class="p">.</span><span class="nf">Json</span><span class="p">(</span><span class="kd">map</span><span class="p">[</span><span class="kt">string</span><span class="p">]</span><span class="kt">string</span><span class="p">&#123;</span><span class="s">&#34;file&#34;</span><span class="p">:</span> <span class="nx">file</span><span class="p">.</span><span class="nx">Filename</span><span class="p">&#125;</span><span class="p">)</span>
+	<span class="p">&#125;</span><span class="p">,</span>
+<span class="p">)</span></code></pre>
+		`,
+	)
+}

--- a/docs/templates/pages/validator.templ
+++ b/docs/templates/pages/validator.templ
@@ -38,7 +38,13 @@ templ Validator() {
 	<p><code>FileField</code> builds on <code>FormFile</code> to cover the common case of accepting a single file under known constraints. You declare a <code>FileConstraint</code> (field name, <code>Required</code>, <code>MaxBytes</code>, <code>AllowedTypes</code>) and it runs the required / size / content-type checks on your behalf, storing a validated <code>UploadedFile</code> under <code>TargetFormFile</code>. The handler keeps only the domain logic — open the file and stream it on:</p>
 	@code.Validatorfilefieldgo()
 	<div class={ styles.Callout() }>
-		<code>AllowedTypes</code> is matched against the content type <em>sniffed</em> from the file's leading bytes (via <code>http.DetectContentType</code>), not the client-supplied <code>Content-Type</code> header, so a renamed or mislabelled upload is still rejected. A constraint violation returns a <code>*validator.FileError</code> (with <code>Field</code> and <code>Reason</code>: <code>FileErrRequired</code>, <code>FileErrTooLarge</code>, or <code>FileErrUnsupportedType</code>) which flows to <code>app.OnError</code> — render it however your API formats errors. Use <code>validator.File</code> (the <code>fn</code> form) when you also need the form's text fields alongside the file.
+		<code>AllowedTypes</code> is matched against the content type <em>sniffed</em> from the file's leading bytes (via <code>http.DetectContentType</code>), not the client-supplied <code>Content-Type</code> header, so a renamed or mislabelled upload is still rejected. By default a constraint violation returns a <code>*validator.FileError</code> (with <code>Field</code> and <code>Reason</code>: <code>FileErrRequired</code>, <code>FileErrTooLarge</code>, or <code>FileErrUnsupportedType</code>) which flows to <code>app.OnError</code> — render it however your API formats errors. Use <code>validator.File</code> (the <code>fn</code> form) when you also need the form's text fields alongside the file.
+	</div>
+	<h2>Customizing File Validation Errors</h2>
+	<p>When you want a violation handled where it happens rather than centrally in <code>app.OnError</code>, pass <code>validator.WithFileError</code> to <code>FileField</code> or <code>File</code>. The handler receives the <code>*FileError</code> and the context, so it can branch on <code>Reason</code>, write its own response and return <code>validator.ErrStop</code>, or transform the violation into any other <code>error</code>. Without it the default behaviour (return the raw <code>*FileError</code> to <code>app.OnError</code>) is unchanged:</p>
+	@code.Validatorfileerrorgo()
+	<div class={ styles.Callout() }>
+		<code>WithFileError</code> only runs for <code>*FileError</code> constraint violations. Parse failures and I/O errors (e.g. a malformed multipart body) still flow straight to <code>app.OnError</code>.
 	</div>
 	<h2>Target Keys</h2>
 	<table>

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -1,6 +1,7 @@
 package validator
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"mime"
@@ -186,7 +187,8 @@ func File[Bindings any, T any](
 		form := raw.MultipartForm
 		file, err := validateFile(form, c)
 		if err != nil {
-			if fe, ok := err.(*FileError); ok && o.onError != nil {
+			var fe *FileError
+			if o.onError != nil && errors.As(err, &fe) {
 				return fileInput{}, o.onError(fe, ctx)
 			}
 			return fileInput{}, err

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -137,6 +137,31 @@ type fileInput struct {
 	form *multipart.Form
 }
 
+// FileErrorHandler maps a constraint violation to a response. It receives the
+// *FileError describing the violation and the request context, and returns the
+// error that drives the handler chain: return ErrStop after writing a response,
+// or return any error to flow to app.OnError.
+type FileErrorHandler[Bindings any] func(*FileError, interfaces.IContext[Bindings]) error
+
+// fileOptions collects the configurable behaviour of File/FileField.
+type fileOptions[Bindings any] struct {
+	onError FileErrorHandler[Bindings]
+}
+
+// FileOption customizes File/FileField. Build one with WithFileError.
+type FileOption[Bindings any] func(*fileOptions[Bindings])
+
+// WithFileError overrides the default constraint-violation handling. Without it
+// File/FileField return the raw *FileError to app.OnError; with it the handler
+// decides the response (e.g. write a body and return ErrStop, or transform the
+// error). The handler only runs for *FileError violations — parse and I/O
+// errors still flow straight to app.OnError.
+func WithFileError[Bindings any](h FileErrorHandler[Bindings]) FileOption[Bindings] {
+	return func(o *fileOptions[Bindings]) {
+		o.onError = h
+	}
+}
+
 // File parses a multipart/form-data body, validates the file field named by c
 // against its constraints, then passes the validated UploadedFile and the full
 // *multipart.Form (for the text Value fields) to fn. The returned value is
@@ -147,7 +172,12 @@ type fileInput struct {
 func File[Bindings any, T any](
 	c FileConstraint,
 	fn func(UploadedFile, *multipart.Form, interfaces.IContext[Bindings]) (T, error),
+	opts ...FileOption[Bindings],
 ) interfaces.HandlerFunc[Bindings] {
+	var o fileOptions[Bindings]
+	for _, opt := range opts {
+		opt(&o)
+	}
 	return newValidator(TargetFormFile, func(ctx interfaces.IContext[Bindings]) (fileInput, error) {
 		raw := ctx.Req().Raw()
 		if err := raw.ParseMultipartForm(formFileMaxMemory); err != nil {
@@ -156,6 +186,9 @@ func File[Bindings any, T any](
 		form := raw.MultipartForm
 		file, err := validateFile(form, c)
 		if err != nil {
+			if fe, ok := err.(*FileError); ok && o.onError != nil {
+				return fileInput{}, o.onError(fe, ctx)
+			}
 			return fileInput{}, err
 		}
 		return fileInput{file: file, form: form}, nil
@@ -168,10 +201,10 @@ func File[Bindings any, T any](
 // and stores the resulting UploadedFile under TargetFormFile ("formFile"),
 // ready to retrieve with Valid[UploadedFile]. Use File when you also need the
 // form's text fields.
-func FileField[Bindings any](c FileConstraint) interfaces.HandlerFunc[Bindings] {
+func FileField[Bindings any](c FileConstraint, opts ...FileOption[Bindings]) interfaces.HandlerFunc[Bindings] {
 	return File(c, func(file UploadedFile, _ *multipart.Form, _ interfaces.IContext[Bindings]) (UploadedFile, error) {
 		return file, nil
-	})
+	}, opts...)
 }
 
 // validateFile checks the file part named by c against its constraints. When

--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -652,6 +652,80 @@ func TestFileField_UnsupportedType_ReturnsFileError(t *testing.T) {
 	assert.Equal(t, validator.FileErrUnsupportedType, fe.Reason)
 }
 
+// A custom error handler passed to FileField is invoked on a constraint
+// violation instead of the default *FileError. It receives the FileError and
+// the context, and may write its own response and return ErrStop.
+func TestFileField_CustomErrorHandler_OverridesDefault(t *testing.T) {
+	var gotReason string
+	nextCalled := false
+
+	app := takibi.New(&Bindings{})
+	app.Post("/upload",
+		validator.FileField[Bindings](
+			validator.FileConstraint{Field: "avatar", Required: true},
+			validator.WithFileError(func(fe *validator.FileError, c MyContext) error {
+				gotReason = fe.Reason
+				c.Status(http.StatusBadRequest).Text("custom: " + fe.Reason)
+				return validator.ErrStop
+			}),
+		),
+		func(c MyContext) error {
+			nextCalled = true
+			return c.Text("unreachable")
+		},
+	)
+
+	// multipart body with no file field
+	body := &bytes.Buffer{}
+	mw := multipart.NewWriter(body)
+	_ = mw.WriteField("title", "x")
+	_ = mw.Close()
+	req := httptest.NewRequest(http.MethodPost, "/upload", body)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	w := httptest.NewRecorder()
+
+	app.ServeHTTP(w, req)
+
+	assert.False(t, nextCalled)
+	assert.Equal(t, validator.FileErrRequired, gotReason)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, "custom: required", w.Body.String())
+}
+
+// File also accepts a custom error handler, which can transform the FileError
+// into an arbitrary error that flows to app.OnError.
+func TestFile_CustomErrorHandler_TransformsError(t *testing.T) {
+	var captured error
+
+	app := takibi.New(&Bindings{})
+	app.OnError(func(c MyContext, err error) error {
+		captured = err
+		return c.Status(http.StatusBadRequest).Text("err")
+	})
+	app.Post("/upload",
+		validator.File(
+			validator.FileConstraint{Field: "avatar", MaxBytes: 4},
+			func(file validator.UploadedFile, form *multipart.Form, c MyContext) (validator.UploadedFile, error) {
+				return file, nil
+			},
+			validator.WithFileError(func(fe *validator.FileError, c MyContext) error {
+				return errors.New("converted: " + fe.Reason)
+			}),
+		),
+		func(c MyContext) error { return c.Text("unreachable") },
+	)
+
+	body, contentType := buildMultipart(t, "title", "x", "avatar", "a.png", pngBytes())
+	req := httptest.NewRequest(http.MethodPost, "/upload", body)
+	req.Header.Set("Content-Type", contentType)
+	w := httptest.NewRecorder()
+
+	app.ServeHTTP(w, req)
+
+	assert.EqualError(t, captured, "converted: too_large")
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
 func TestFileField_OptionalAbsent_StoresZeroValue(t *testing.T) {
 	called := false
 


### PR DESCRIPTION
Closes #111

## 概要

`validator.FileField` / `validator.File` の制約違反時のエラー処理を、ユーザーがコントロールできるようにしました。default は現状どおり `*FileError` を `app.OnError` に流す挙動を維持しています。

## 変更点

- `WithFileError` オプションを追加。`File` / `FileField` に可変長引数として渡せる。
- ハンドラのシグネチャは `func(*FileError, IContext[Bindings]) error`。`FileError` の `Field` / `Reason` を受け取り、自前でレスポンスを書いて `ErrStop` を返す、あるいは任意の `error` へ変換できる。
- オプション未指定時は従来通り `*FileError` を返し `app.OnError` に流れる（後方互換）。
- `WithFileError` は `*FileError`（制約違反）のときのみ呼ばれる。multipart のパース失敗・I/O エラーはこれまで通り直接 `app.OnError` に流れる。

```go
validator.FileField[Bindings](
    validator.FileConstraint{Field: "avatar", Required: true},
    validator.WithFileError(func(fe *validator.FileError, c MyContext) error {
        c.Status(http.StatusBadRequest).Json(map[string]string{"reason": fe.Reason})
        return validator.ErrStop
    }),
)
```

## 実装メモ

- TDD で実装（`validator/validator_test.go` に `FileField` / `File` 両方のカスタムハンドラのテストを追加）。
- 既存の `FileField(c)` / `File(c, fn)` 呼び出しは可変長引数なのでシグネチャ非破壊。
- API 変更に伴い `/docs`（validator ページ + コード例）を更新。

## テスト

- `go test ./...` 全パス
- `go build ./...` / docs モジュールのビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)