### PR TITLE
feat(wasm): support Blow scheduled tasks via Cloudflare Cron Triggers

### DIFF
--- a/docs/templates/pages/blow.templ
+++ b/docs/templates/pages/blow.templ
@@ -7,7 +7,7 @@ templ Blow() {
 	<h1>Background Tasks</h1>
 	<p class={ styles.Lead() }><code>app.Blow</code> registers tasks that run outside the request lifecycle. Tasks can trigger on server start/stop, or run on a cron schedule.</p>
 	<div class={ styles.Callout(), styles.CalloutWarning() }>
-		Blow tasks are not supported on WASM / Cloudflare Workers. Use them only with the native Go server.
+		On WASM / Cloudflare Workers only <code>&#34;schedule&#34;</code> tasks are supported, dispatched by Cloudflare Cron Triggers. <code>&#34;trigger&#34;</code> (start/stop) tasks remain native-only because Workers are stateless.
 	</div>
 	<h2>Trigger Tasks</h2>
 	<p>Set <code>BlowActionTag</code> to <code>&#34;trigger&#34;</code> and <code>BlowActionTrigger</code> to <code>&#34;start&#34;</code> or <code>&#34;stop&#34;</code> to run code when the server boots or shuts down:</p>
@@ -15,6 +15,17 @@ templ Blow() {
 	<h2>Scheduled Tasks</h2>
 	<p>Set <code>BlowActionTag</code> to <code>&#34;schedule&#34;</code> and provide a cron expression in <code>BlowActionSchedule</code>. The scheduler uses <a href="https://pkg.go.dev/github.com/robfig/cron/v3" target="_blank" rel="noopener">robfig/cron</a> with optional seconds support:</p>
 	@code.Blowschedulego()
+	<h2>On Cloudflare Workers (WASM)</h2>
+	<p>When built for WASM, scheduled tasks are dispatched by <a href="https://developers.cloudflare.com/workers/configuration/cron-triggers/" target="_blank" rel="noopener">Cloudflare Cron Triggers</a> instead of <code>robfig/cron</code>. The firing schedule is defined in <code>wrangler.jsonc</code>:</p>
+	<pre>
+		<span class={ styles.PreLabel() }>jsonc</span>
+		<code>
+			&#34;triggers&#34;: &#123;
+			&nbsp;&nbsp;&#34;crons&#34;: [&#34;*/5 * * * *&#34;]
+			&#125;
+		</code>
+	</pre>
+	<p><code>BlowActionSchedule</code> must <strong>exactly match</strong> a cron expression listed in <code>triggers.crons</code> (standard 5-field cron, no seconds). The dispatcher runs every schedule task whose <code>BlowActionSchedule</code> equals the fired event&#39;s cron expression; leave it empty to run on every trigger.</p>
 	<h2>BlowTask Reference</h2>
 	<table>
 		<thead>

--- a/examples/syumai-worker/go.mod
+++ b/examples/syumai-worker/go.mod
@@ -2,9 +2,6 @@ module github.com/poteto0/takibi-examples-worker
 
 go 1.26.1
 
-require (
-	github.com/poteto0/takibi v0.0.0-20260409114531-f94e5ca238c0
-	github.com/syumai/workers v0.32.0
-)
+require github.com/poteto0/takibi v0.0.0-20260409114531-f94e5ca238c0
 
 require github.com/robfig/cron/v3 v3.0.1 // indirect

--- a/examples/syumai-worker/go.sum
+++ b/examples/syumai-worker/go.sum
@@ -8,7 +8,5 @@ github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
 github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/syumai/workers v0.32.0 h1:nL7c6d52YgHUDFiYxRffmJCK60yVkzTb2YtBPmHZOxQ=
-github.com/syumai/workers v0.32.0/go.mod h1:ZnqmdiHNBrbxOLrZ/HJ5jzHy6af9cmiNZk10R9NrIEA=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/examples/syumai-worker/main.go
+++ b/examples/syumai-worker/main.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/poteto0/takibi"
 	"github.com/poteto0/takibi/interfaces"
-	"github.com/syumai/workers"
 )
 
 type Bindings struct {
@@ -25,8 +24,12 @@ func main() {
 
 	app := takibi.New(bindings)
 
-	app.OnError(func(ctx interfaces.IContext[Bindings], err error) error {
+	app.OnError(func(ctx MyContext, err error) error {
 		return ctx.Status(500).Text("internal-server-error")
+	})
+
+	app.OnBlowError(func(ctx MyContext, err error) {
+		fmt.Println("scheduled task failed:", err.Error())
 	})
 
 	app.Get("/hello", func(ctx MyContext) error {
@@ -37,5 +40,21 @@ func main() {
 		})
 	})
 
-	workers.Serve(app)
+	// Scheduled task dispatched by Cloudflare Cron Triggers.
+	// BlowActionSchedule must exactly match an entry in wrangler.jsonc
+	// `triggers.crons` (standard 5-field cron, no seconds).
+	app.Blow(interfaces.BlowTask[Bindings]{
+		BlowActionTag:      "schedule",
+		BlowActionSchedule: "*/5 * * * *",
+		BlowAction: func(ctx MyContext) error {
+			fmt.Println("cron fired:", ctx.Env().Foo)
+			return nil
+		},
+	})
+
+	// Fire wires HTTP handlers and Cron Triggers, then blocks until done.
+	// The addr argument is ignored on WASM.
+	if err := app.Fire(""); err != nil {
+		panic(err)
+	}
 }

--- a/examples/syumai-worker/wrangler.jsonc
+++ b/examples/syumai-worker/wrangler.jsonc
@@ -16,7 +16,17 @@
 	"upload_source_maps": true,
 	"compatibility_flags": [
 		"nodejs_compat"
-	]
+	],
+	/**
+	 * Cron Triggers
+	 * https://developers.cloudflare.com/workers/configuration/cron-triggers/
+	 * Each entry must exactly match a BlowActionSchedule used with app.Blow.
+	 */
+	"triggers": {
+		"crons": [
+			"*/5 * * * *"
+		]
+	}
 	/**
 	 * Smart Placement
 	 * https://developers.cloudflare.com/workers/configuration/smart-placement/#smart-placement

--- a/interfaces/itakibi.go
+++ b/interfaces/itakibi.go
@@ -25,7 +25,8 @@ type ITakibi[Bindings any] interface {
 
 	OnError(handler ErrorHandlerFunc[Bindings])
 
-	//	- ! it is not supported for wasm
+	// OnBlowError sets the handler invoked when a Blow task returns an error.
+	//	- on wasm: applies to "schedule" tasks dispatched by Cron Triggers.
 	OnBlowError(handler BlowErrorHandlerFunc[Bindings])
 
 	Use(path string, middleware ...MiddlewareFunc[Bindings]) error
@@ -133,7 +134,11 @@ type ITakibi[Bindings any] interface {
 	On(methods, paths []string, handlers ...HandlerFunc[Bindings]) error
 
 	// Blow registers task
-	//	- ! it is not supported for wasm
+	//	- on native go: "trigger" (start/stop) and "schedule" tasks via robfig/cron.
+	//	- on wasm: only "schedule" tasks, dispatched by Cloudflare Cron Triggers.
+	//	  The firing schedule is defined by wrangler.jsonc `triggers.crons`, and
+	//	  BlowActionSchedule must exactly match a configured cron expression.
+	//	  "trigger" (start/stop) tasks are not supported on wasm.
 	Blow(tasks ...BlowTask[Bindings])
 
 	// Camp simulates a request without starting the server

--- a/interfaces/task.go
+++ b/interfaces/task.go
@@ -1,8 +1,20 @@
 package interfaces
 
+// BlowActionTag values.
+const (
+	BlowTagTrigger  = "trigger"
+	BlowTagSchedule = "schedule"
+)
+
+// BlowActionTrigger values.
+const (
+	BlowTriggerStart = "start"
+	BlowTriggerStop  = "stop"
+)
+
 type BlowTask[Bindings any] struct {
-	BlowActionTag      string // "trigger" or "schedule"
+	BlowActionTag      string // BlowTagTrigger or BlowTagSchedule
 	BlowActionSchedule string // cron schedule or empty
-	BlowActionTrigger  string // "start" or "stop"
+	BlowActionTrigger  string // BlowTriggerStart or BlowTriggerStop
 	BlowAction         func(c IContext[Bindings]) error
 }

--- a/takibi_native.go
+++ b/takibi_native.go
@@ -89,7 +89,7 @@ func (
 	t *takibi[Bindings],
 ) startTasks() {
 	for _, task := range t.tasks {
-		if task.BlowActionTag == "trigger" && task.BlowActionTrigger == "start" {
+		if task.BlowActionTag == interfaces.BlowTagTrigger && task.BlowActionTrigger == interfaces.BlowTriggerStart {
 			r, _ := http.NewRequestWithContext(t.ctx, "GET", "/", nil)
 			c := NewContext(nil, r, t.env, &t.option)
 			go func(task interfaces.BlowTask[Bindings]) {
@@ -99,7 +99,7 @@ func (
 			}(task)
 		}
 
-		if task.BlowActionTag == "schedule" && task.BlowActionSchedule != "" {
+		if task.BlowActionTag == interfaces.BlowTagSchedule && task.BlowActionSchedule != "" {
 			if t.cron == nil {
 				t.cron = cron.New(cron.WithSeconds())
 			}
@@ -148,7 +148,7 @@ func (
 	// execute stop tasks
 	var wg sync.WaitGroup
 	for _, task := range t.tasks {
-		if task.BlowActionTag == "trigger" && task.BlowActionTrigger == "stop" {
+		if task.BlowActionTag == interfaces.BlowTagTrigger && task.BlowActionTrigger == interfaces.BlowTriggerStop {
 			wg.Add(1)
 			go func(task interfaces.BlowTask[Bindings]) {
 				defer wg.Done()

--- a/takibi_wasm.go
+++ b/takibi_wasm.go
@@ -12,14 +12,17 @@ import (
 	"github.com/poteto0/takibi/interfaces"
 	"github.com/poteto0/takibi/router"
 	"github.com/syumai/workers"
+	"github.com/syumai/workers/cloudflare/cron"
 )
 
 type takibi[Bindings any] struct {
-	env          *Bindings
-	cache        sync.Pool
-	router       interfaces.IRouter[Bindings]
-	errorHandler interfaces.ErrorHandlerFunc[Bindings]
-	option       interfaces.TakibiOption
+	env              *Bindings
+	cache            sync.Pool
+	router           interfaces.IRouter[Bindings]
+	errorHandler     interfaces.ErrorHandlerFunc[Bindings]
+	blowErrorHandler interfaces.BlowErrorHandlerFunc[Bindings]
+	tasks            []interfaces.BlowTask[Bindings]
+	option           interfaces.TakibiOption
 
 	ctx    stdContext.Context
 	cancel stdContext.CancelFunc
@@ -42,6 +45,9 @@ func NewWithOption[Bindings any](bindings *Bindings, opt interfaces.TakibiOption
 		errorHandler: func(ctx interfaces.IContext[Bindings], err error) error {
 			return ctx.Status(http.StatusInternalServerError).Text(err.Error())
 		},
+		blowErrorHandler: func(c interfaces.IContext[Bindings], err error) {
+			fmt.Println(err.Error())
+		},
 		ctx:    ctx,
 		cancel: cancel,
 		option: opt,
@@ -53,13 +59,47 @@ func (
 ) Fire(
 	addr string,
 ) error {
-	workers.Serve(t)
+	workers.ServeNonBlock(t)
+	t.startTasks()
+	workers.Ready()
+	<-workers.Done()
 	return nil
 }
 
+// startTasks registers a single Cron Trigger dispatcher when at least one
+// "schedule" task is registered. On Cloudflare Workers the actual firing
+// schedule is defined by wrangler.jsonc `triggers.crons`; each fired event's
+// cron expression is matched against BlowActionSchedule.
 func (
 	t *takibi[Bindings],
 ) startTasks() {
+	var scheduleTasks []interfaces.BlowTask[Bindings]
+	for _, task := range t.tasks {
+		if task.BlowActionTag == interfaces.BlowTagSchedule {
+			scheduleTasks = append(scheduleTasks, task)
+		}
+	}
+	if len(scheduleTasks) == 0 {
+		return
+	}
+
+	cron.ScheduleTaskNonBlock(func(ctx stdContext.Context) error {
+		event, _ := cron.NewEvent(ctx)
+		r, _ := http.NewRequestWithContext(ctx, "GET", "/", nil)
+		c := NewContext(nil, r, t.env, &t.option)
+		for _, task := range scheduleTasks {
+			// When BlowActionSchedule is set, only run for the matching
+			// fired cron expression. An empty schedule runs on every event.
+			if task.BlowActionSchedule != "" && event != nil &&
+				task.BlowActionSchedule != event.Cron {
+				continue
+			}
+			if err := task.BlowAction(c); err != nil {
+				t.blowErrorHandler(c, err)
+			}
+		}
+		return nil
+	})
 }
 
 func (
@@ -151,7 +191,7 @@ func (
 ) OnBlowError(
 	handler interfaces.BlowErrorHandlerFunc[Bindings],
 ) {
-	fmt.Println("it is not supported for wasm")
+	t.blowErrorHandler = handler
 }
 
 func (
@@ -197,7 +237,7 @@ func (
 ) Blow(
 	tasks ...interfaces.BlowTask[Bindings],
 ) {
-	fmt.Println("it is not supported for wasm")
+	t.tasks = append(t.tasks, tasks...)
 }
 
 func (


### PR DESCRIPTION
## Summary

Closes #116. Enables `app.Blow` scheduled tasks to run on Cloudflare Workers (WASM), replacing the previous `fmt.Println("it is not supported for wasm")` no-op stubs.

- `takibi_wasm.go`: add `tasks` / `blowErrorHandler` fields (mirroring native) with a default handler; implement `Blow` and `OnBlowError`.
- `startTasks` registers a single `cron.ScheduleTaskNonBlock` dispatcher when schedule tasks exist. Each fired event's cron expression is matched against `BlowActionSchedule` (empty = runs on every event).
- `Fire` switches from blocking `workers.Serve` to `ServeNonBlock` + `startTasks` + `Ready` + `<-Done`, so HTTP handlers and Cron Triggers are wired together.
- `trigger` (start/stop) tasks stay native-only — Workers are stateless.

## Cleanup (from `/simplify`)

- Added shared `BlowTag*` / `BlowTrigger*` constants in `interfaces/task.go`, replacing magic strings in both wasm and native dispatch.
- wasm `startTasks` filters schedule tasks once into a slice captured by the dispatcher, instead of a pre-scan loop + per-event re-scan over all tasks.

## Docs & example

- `interfaces/itakibi.go`: updated `Blow` / `OnBlowError` doc comments (no longer "not supported for wasm").
- `docs/templates/pages/blow.templ`: documents WASM cron usage, `wrangler.jsonc` `triggers.crons`, and the exact-match requirement (standard 5-field cron, no seconds).
- `examples/syumai-worker`: schedule example via `app.Fire`, plus `triggers.crons`.

## Notes

- The cron expression in `BlowActionSchedule` must **exactly match** a `triggers.crons` entry (matched against `event.Cron`), so it uses standard cron syntax — unlike native's `robfig/cron` which supports seconds (`@every 1s`).

## Test plan

- [x] `go build ./...` (native) and `GOOS=js GOARCH=wasm go build ./...` pass
- [x] `go test` suite passes (incl. `TestBlow_*`)
- [x] `golangci-lint run` clean
- [x] example builds for `GOOS=js GOARCH=wasm`

🤖 Generated with [Claude Code](https://claude.com/claude-code)