### PR TITLE
fix: propagate ancestor middlewares through Linearize for app.Route

### DIFF
--- a/router/node.go
+++ b/router/node.go
@@ -260,7 +260,7 @@ func (
 ) Linearize() []interfaces.NodeUnit[Bindings] {
 	visited := make(map[string]struct{})
 	results := []interfaces.NodeUnit[Bindings]{}
-	n.dfs(n, "", &visited, &results)
+	n.dfs(n, "", nil, &visited, &results)
 	return results
 }
 
@@ -269,6 +269,7 @@ func (
 ) dfs(
 	curr *node[Bindings],
 	path string,
+	accumulated []interfaces.MiddlewareFunc[Bindings],
 	visited *map[string]struct{},
 	results *[]interfaces.NodeUnit[Bindings],
 ) {
@@ -281,17 +282,20 @@ func (
 	}
 	(*visited)[path] = struct{}{}
 
+	all := make([]interfaces.MiddlewareFunc[Bindings], len(accumulated)+len(curr.middlewares))
+	copy(all, accumulated)
+	copy(all[len(accumulated):], curr.middlewares)
+
 	if curr.handler != nil {
 		*results = append(*results, interfaces.NodeUnit[Bindings]{
 			Path:       path,
 			Handler:    curr.handler,
-			Middleware: curr.middlewares,
+			Middleware: all,
 		})
 	}
 
 	for key, child := range curr.children {
-		childNode := child.(*node[Bindings])
 		nextPath := path + "/" + key
-		n.dfs(childNode, nextPath, visited, results)
+		n.dfs(child.(*node[Bindings]), nextPath, all, visited, results)
 	}
 }

--- a/router/node_test.go
+++ b/router/node_test.go
@@ -284,6 +284,32 @@ func TestNode_ComposedHandler(t *testing.T) {
 
 func TestNode_Linearize(t *testing.T) {
 	emptyHandler := func(ctx interfaces.IContext[any]) error { return nil }
+	mw := func(c interfaces.IContext[any], next interfaces.HandlerFunc[any]) error { return nil }
+
+	t.Run("ancestor middleware is included in child NodeUnit", func(t *testing.T) {
+		n := NewNode[any]()
+		n.AddMiddleware("/", mw)
+		n.Add("/hello", emptyHandler)
+
+		units := n.Linearize()
+
+		assert.Len(t, units, 1)
+		assert.Equal(t, "/hello", units[0].Path)
+		assert.Len(t, units[0].Middleware, 1, "root middleware should be inherited by /hello NodeUnit")
+	})
+
+	t.Run("multiple levels of ancestor middleware are all included", func(t *testing.T) {
+		n := NewNode[any]()
+		mw2 := func(c interfaces.IContext[any], next interfaces.HandlerFunc[any]) error { return nil }
+		n.AddMiddleware("/", mw)
+		n.AddMiddleware("/api", mw2)
+		n.Add("/api/users", emptyHandler)
+
+		units := n.Linearize()
+
+		assert.Len(t, units, 1)
+		assert.Len(t, units[0].Middleware, 2, "both root and /api middlewares should be in NodeUnit")
+	})
 
 	t.Run("Linearize all nodes", func(t *testing.T) {
 		// Arrange

--- a/takibi_test.go
+++ b/takibi_test.go
@@ -205,6 +205,26 @@ func TestTakibi_Router(t *testing.T) {
 		assert.Equal(t, http.StatusOK, resp.StatusCode())
 	})
 
+	t.Run("middleware in sub-app is applied via Route", func(t *testing.T) {
+		called := false
+		mw := func(c interfaces.IContext[any], next interfaces.HandlerFunc[any]) error {
+			called = true
+			return next(c)
+		}
+
+		subApp := newNilApp()
+		subApp.Use("/", mw)
+		subApp.Get("/hello", handler)
+
+		app := newNilApp()
+		err := app.Route("/api", subApp)
+		assert.Nil(t, err)
+
+		resp := app.Camp("GET", "/api/hello")
+		assert.Equal(t, http.StatusOK, resp.StatusCode())
+		assert.True(t, called, "sub-app middleware should have been called")
+	})
+
 	t.Run("return error if duplicate when Route", func(t *testing.T) {
 		// Arrange
 		app1 := newNilApp()


### PR DESCRIPTION
## Summary

- Fixes #118: `app.Route` now correctly applies middleware registered in the sub-app
- `dfs` in `router/node.go` now accumulates ancestor middlewares as it walks the tree, so each `NodeUnit` carries the full middleware chain (own + all ancestors)
- `make`/`copy` pattern used for consistency with `walkAndCompose`; intermediate `childNode` variable inlined

## Root cause

`dfs` only put `curr.middlewares` (the node's own middlewares) into `NodeUnit.Middleware`, dropping ancestor middlewares. When `Route()` called `LinearizeTree()` and re-registered middleware via `router.Use(fullPath, route.Middleware...)`, the root-level `Use` from the sub-app was silently lost.

## Test plan

- [ ] `TestNode_Linearize/ancestor_middleware_is_included_in_child_NodeUnit` — unit test for the `dfs` fix
- [ ] `TestNode_Linearize/multiple_levels_of_ancestor_middleware_are_all_included` — multi-level ancestor chain
- [ ] `TestTakibi_Router/middleware_in_sub-app_is_applied_via_Route` — end-to-end integration test matching the issue scenario
- [ ] `go test ./...` — all existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)