### PR TITLE
ci: verify wasm build in CI and unify Go version across workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,12 +9,12 @@ on:
       - main
 
 env:
-  GO_VERSION: "1.26.1"
   JUST_VERSION: "1.45.0"
 
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -22,7 +22,7 @@ jobs:
       - name: Use golang
         uses: actions/setup-go@v6
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
           cache: true
 
       - name: Setup just
@@ -36,6 +36,12 @@ jobs:
       - name: run lint with just
         run: just lint
 
+      - name: run lint on wasm build tags with just
+        run: just lint-wasm
+
+      - name: run wasm build with just
+        run: just build-wasm
+
   test:
     runs-on: ubuntu-latest
     steps:
@@ -45,7 +51,7 @@ jobs:
       - name: Use golang
         uses: actions/setup-go@v6
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
           cache: true
 
       - name: Setup just

--- a/.github/workflows/code-analysis.yaml
+++ b/.github/workflows/code-analysis.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Use golang
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.1"
+          go-version-file: go.mod
           cache: true
 
       - name: Initialize CodeQL

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -15,7 +15,6 @@ on:
       - '.github/workflows/deploy-docs.yml'
 
 env:
-  GO_VERSION: "1.26.1"
   TEMPL_VERSION: "v0.3.1020"
   JUST_VERSION: "1.45.0"
 
@@ -28,7 +27,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: docs/go.mod
           cache: true
           cache-dependency-path: docs/go.sum
 
@@ -70,7 +69,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: docs/go.mod
           cache: true
           cache-dependency-path: docs/go.sum
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,10 @@ just -l
 
 - develop with tdd
 - always update docs(`/docs`), if api changed.
+- build tags: `*_wasm.go` must carry `//go:build wasm`, `*_native.go` must carry `//go:build !wasm`.
+  Go implies the constraint from the `_wasm` filename suffix but **not** from `_native`,
+  so a `*_native.go` without the explicit tag is silently compiled into the wasm build too.
+  Verify both targets with `just build-wasm` and `just lint-wasm`.
 
 ## docs
 

--- a/camp_response_native.go
+++ b/camp_response_native.go
@@ -1,3 +1,5 @@
+//go:build !wasm
+
 package takibi
 
 import (

--- a/justfile
+++ b/justfile
@@ -6,6 +6,12 @@ ut:
 lint:
   golangci-lint run -c .golangci.yaml
 
+build-wasm:
+  GOOS=js GOARCH=wasm go build ./...
+
+lint-wasm:
+  GOOS=js GOARCH=wasm GOLANGCI_LINT_CACHE="$HOME/.cache/golangci-lint-wasm" golangci-lint run -c .golangci.yaml
+
 fmt:
   go fmt ./...
   templ fmt .
@@ -13,7 +19,7 @@ fmt:
 bench:
   go test -bench=. -benchmem -run='^$' ./...
 
-ci: ut lint fmt
+ci: ut lint lint-wasm build-wasm fmt
 
 gen:
   templ generate

--- a/takibi_wasm.go
+++ b/takibi_wasm.go
@@ -112,17 +112,6 @@ func (
 
 func (
 	t *takibi[Bindings],
-) stopTasks(ctx stdContext.Context) {
-}
-
-func (
-	t *takibi[Bindings],
-) setupServer() error {
-	return nil
-}
-
-func (
-	t *takibi[Bindings],
 ) ServeHTTP(
 	w http.ResponseWriter,
 	r *http.Request,


### PR DESCRIPTION
Closes #127, closes #133.

## #127 — wasm build is now verified in CI

`takibi_wasm.go` sits behind a build tag, so neither `go test ./...` nor `golangci-lint` ever compiled it. Cloudflare Workers support is a headline feature, so a regression there would have gone undetected.

- Added `build-wasm` and `lint-wasm` recipes to the `justfile` and run both in CI, so the checks are reproducible locally (per AGENTS.md, commands go through `just`).
- Wired both into the `ci:` aggregate, so `just ci` checks the same things CI does.
- `lint-wasm` uses a separate `GOLANGCI_LINT_CACHE`: golangci-lint holds an exclusive lock on its cache dir and **fails** a second invocation fired back-to-back (reproduced locally). Separate cache dirs also avoid the two targets thrashing each other's analysis cache.
- Both run as steps of the existing `lint` job rather than as a new job. A separate job would repeat the entire checkout/setup-go/setup-just scaffold for one command, and `actions/setup-go` derives its cache key from the *runner* arch — not from `GOOS`/`GOARCH` — so a parallel wasm job would race `lint`/`test` for a byte-identical cache key and its wasm build cache would never actually persist.

### Two real latent defects surfaced by turning this on

Both are exactly the class of regression #127 exists to catch:

- **`camp_response_native.go` carried no build tag.** Go implies a build constraint from the `_wasm` filename suffix but **not** from `_native`, so this file was compiled into the wasm build while its only caller (`takibi_native.go`, tagged `!wasm`) was excluded. Tagged `//go:build !wasm` to match its sibling. Safe: wasm's `Camp()` returns `nil` and never referenced it.
- **`takibi_wasm.go` had two dead stub methods** (`stopTasks`, `setupServer`) copied from the native variant — called from nowhere in the wasm build path and not part of `interfaces.ITakibi`. Removed. The native equivalents are untouched and still used.

The build-tag convention is now documented in `AGENTS.md`, so the gap that let the untagged file through is stated rather than left to be rediscovered.

## #133 — Go version unified

`code-analysis.yaml` pinned Go `1.25.1` while `ci.yml` and `deploy-docs.yml` used `1.26.1`, meaning CodeQL analyzed a different toolchain than CI built.

All workflows now derive the version via `go-version-file`, and the duplicated `GO_VERSION` env vars are gone. `deploy-docs.yml` points at `docs/go.mod` because that is the module it actually builds (`working-directory: docs`, `cache-dependency-path: docs/go.sum`); the others point at the root `go.mod`.

## Verification

All run locally, all passing:

| command | result |
|---|---|
| `go build ./...` | ok |
| `just build-wasm` | ok |
| `just lint` | `0 issues.` |
| `just lint-wasm` | `0 issues.` |
| `just lint` → `just lint-wasm` back-to-back | ok (no cache-lock failure) |
| `just ut` | all packages ok, coverage unchanged (93.9 / 98.1 / 100 / 100 / 98.8 / 100 / 92.2 %) |
| workflow YAML parse | ok |

## Follow-ups (not in this PR)

- The wasm build covers the `takibi` library, not `examples/syumai-worker` (a separate module, and the template users actually copy) — that is #126's scope.
- True cross-module Go-version centralization still isn't there: root `go.mod` and `docs/go.mod` are independently editable and nothing fails when they drift. Filed as a follow-up rather than expanded here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)