### PR TITLE
docs: clarify that app.Route discards the sub app's Bindings

### DIFF
--- a/docs/templates/pages/sub_routing.templ
+++ b/docs/templates/pages/sub_routing.templ
@@ -11,6 +11,9 @@ templ SubRouting() {
 	<div class={ styles.Callout() }>
 		Middleware registered on the child app's routes is preserved when mounted. Middleware registered on the parent (via <code>app.Use</code>) applies to all merged routes.
 	</div>
+	<div class={ styles.Callout(), styles.CalloutWarning() }>
+		The child app's <code>Bindings</code> are discarded. <code>ctx.Env()</code> returns the parent's <code>Bindings</code> even inside handlers registered on the child app, so pass every binding to the parent app.
+	</div>
 	<h2>All and On</h2>
 	<p><code>app.All</code> registers a handler for every HTTP method on a single path. <code>app.On</code> registers one handler across multiple methods and paths at once:</p>
 	<pre>

--- a/interfaces/itakibi.go
+++ b/interfaces/itakibi.go
@@ -42,6 +42,9 @@ type ITakibi[Bindings any] interface {
 	//  app.Route("/api", api)
 	//
 	// then, GET /api/users will return "users"
+	//
+	//	- ! the sub app's Bindings are discarded: ctx.Env() always returns
+	//	  the parent's Bindings, so pass every binding to the parent app.
 	Route(basePath string, app ITakibi[Bindings]) error
 
 	/* add node */

--- a/takibi_test.go
+++ b/takibi_test.go
@@ -3,6 +3,7 @@ package takibi
 import (
 	stdContext "context"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -223,6 +224,24 @@ func TestTakibi_Router(t *testing.T) {
 		resp := app.Camp("GET", "/api/hello")
 		assert.Equal(t, http.StatusOK, resp.StatusCode())
 		assert.True(t, called, "sub-app middleware should have been called")
+	})
+
+	t.Run("sub-app Bindings are discarded, parent's are used", func(t *testing.T) {
+		type probeBindings struct {
+			Name string
+		}
+
+		sub := New(&probeBindings{Name: "sub"})
+		sub.Get("/who", func(c interfaces.IContext[probeBindings]) error {
+			return c.Text(c.Env().Name)
+		})
+
+		parent := New(&probeBindings{Name: "parent"})
+		assert.Nil(t, parent.Route("/api", sub))
+
+		body, err := io.ReadAll(parent.Camp("GET", "/api/who").Raw().Body)
+		assert.Nil(t, err)
+		assert.Equal(t, "parent", string(body))
 	})
 
 	t.Run("return error if duplicate when Route", func(t *testing.T) {


### PR DESCRIPTION
closes #139 / #123 の (3)

## 背景

`Route(basePath, app)` は `LinearizeTree()` でサブアプリのルートとミドルウェアだけを親にコピーする。ハンドラを実行するのは親の `ServeHTTP` なので、`ctx.Env()` は常に**親の Bindings** を返し、サブアプリに渡した `*Bindings` は無視される。エラーも警告も出ないため利用者が気づけない。

## 変更

- `interfaces.ITakibi.Route` の doc comment に注意書きを追記（既存の `- ! ...` 記法に合わせた）
- `/docs` の Sub-Routing ページに warning callout を追加
- 現在の挙動を固定するリグレッションテストを追加（`TestTakibi_Router`）

挙動の変更はなし。ドキュメントとテストのみ。

## スコープ外

サブアプリ由来のハンドラをサブアプリの env で実行する対応は設計変更を伴うため別途（#123 (1) と関連）。

## 確認

`just ut` / `just lint` / `just lint-wasm` / `just build-wasm` すべて green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)