### PR TITLE
fix: inherit the sub app's errorHandler in app.Route

### DIFF
--- a/docs/templates/pages/sub_routing.templ
+++ b/docs/templates/pages/sub_routing.templ
@@ -11,8 +11,11 @@ templ SubRouting() {
 	<div class={ styles.Callout() }>
 		Middleware registered on the child app's routes is preserved when mounted. Middleware registered on the parent (via <code>app.Use</code>) applies to all merged routes.
 	</div>
+	<div class={ styles.Callout() }>
+		An error handler registered on the child app via <code>app.OnError</code> is inherited: errors returned by the child app's handlers are handled by it instead of the parent's. If that handler itself returns an error, the error falls through to the parent's error handler. A child app that never calls <code>OnError</code> simply uses the parent's.
+	</div>
 	<div class={ styles.Callout(), styles.CalloutWarning() }>
-		The child app's <code>Bindings</code> are discarded. <code>ctx.Env()</code> returns the parent's <code>Bindings</code> even inside handlers registered on the child app, so pass every binding to the parent app.
+		The child app's <code>Bindings</code> are discarded. <code>ctx.Env()</code> returns the parent's <code>Bindings</code> even inside handlers registered on the child app, so pass every binding to the parent app. Blow tasks registered on the child app (and the <code>OnBlowError</code> handler) are not merged either.
 	</div>
 	<h2>All and On</h2>
 	<p><code>app.All</code> registers a handler for every HTTP method on a single path. <code>app.On</code> registers one handler across multiple methods and paths at once:</p>

--- a/error_handler.go
+++ b/error_handler.go
@@ -1,0 +1,30 @@
+package takibi
+
+import (
+	"github.com/poteto0/takibi/interfaces"
+)
+
+// handleError dispatches to the handler registered by OnError, falling back to
+// the build-specific defaultErrorHandler. errorHandler stays nil until OnError
+// sets one, which is also how Route tells whether a sub app customized it.
+func (t *takibi[Bindings]) handleError(ctx interfaces.IContext[Bindings], err error) error {
+	if t.errorHandler == nil {
+		return defaultErrorHandler(ctx, err)
+	}
+	return t.errorHandler(ctx, err)
+}
+
+// wrapWithErrorHandler lets a sub app handle its own errors with the handler it
+// registered via OnError. An error returned by that handler still flows to the
+// parent's error handler.
+func wrapWithErrorHandler[Bindings any](
+	handler interfaces.HandlerFunc[Bindings],
+	errorHandler interfaces.ErrorHandlerFunc[Bindings],
+) interfaces.HandlerFunc[Bindings] {
+	return func(c interfaces.IContext[Bindings]) error {
+		if err := handler(c); err != nil {
+			return errorHandler(c, err)
+		}
+		return nil
+	}
+}

--- a/interfaces/itakibi.go
+++ b/interfaces/itakibi.go
@@ -43,8 +43,12 @@ type ITakibi[Bindings any] interface {
 	//
 	// then, GET /api/users will return "users"
 	//
+	//	- the sub app's error handler set by OnError is inherited: errors from
+	//	  its handlers go to it, and an error it returns falls through to the
+	//	  parent's error handler.
 	//	- ! the sub app's Bindings are discarded: ctx.Env() always returns
 	//	  the parent's Bindings, so pass every binding to the parent app.
+	//	- ! the sub app's Blow tasks and OnBlowError handler are not merged.
 	Route(basePath string, app ITakibi[Bindings]) error
 
 	/* add node */

--- a/route.go
+++ b/route.go
@@ -5,7 +5,45 @@ import (
 
 	"github.com/poteto0/takibi/constants"
 	"github.com/poteto0/takibi/interfaces"
+	"github.com/poteto0/takibi/router"
 )
+
+func (
+	t *takibi[Bindings],
+) Route(
+	basePath string,
+	app interfaces.ITakibi[Bindings],
+) error {
+	// a sub app that never called OnError has no handler of its own to inherit
+	var subErrorHandler interfaces.ErrorHandlerFunc[Bindings]
+	if sub, ok := app.(*takibi[Bindings]); ok {
+		subErrorHandler = sub.errorHandler
+	}
+
+	linearRoutes := app.Router().LinearizeTree()
+	for _, method := range router.SupportedHttpMethod {
+		for _, route := range linearRoutes[method] {
+			fullPath := basePath + route.Path
+
+			handler := route.Handler
+			if subErrorHandler != nil {
+				handler = wrapWithErrorHandler(handler, subErrorHandler)
+			}
+
+			if err := t.router.Add(method, fullPath, handler); err != nil {
+				return err
+			}
+
+			if len(route.Middleware) == 0 {
+				continue
+			}
+			if err := t.router.Use(fullPath, route.Middleware...); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
 
 // register chains the handlers and delegates to add. It returns
 // constants.ErrNoHandler when no handler is provided.

--- a/takibi_native.go
+++ b/takibi_native.go
@@ -19,9 +19,10 @@ import (
 )
 
 type takibi[Bindings any] struct {
-	env              *Bindings
-	cache            sync.Pool
-	router           interfaces.IRouter[Bindings]
+	env    *Bindings
+	cache  sync.Pool
+	router interfaces.IRouter[Bindings]
+	// errorHandler is nil until OnError sets one, see handleError
 	errorHandler     interfaces.ErrorHandlerFunc[Bindings]
 	blowErrorHandler interfaces.BlowErrorHandlerFunc[Bindings]
 	tasks            []interfaces.BlowTask[Bindings]
@@ -33,6 +34,11 @@ type takibi[Bindings any] struct {
 	fireMutex sync.RWMutex
 	Server    http.Server
 	Listener  net.Listener
+}
+
+// defaultErrorHandler is used until OnError installs one.
+func defaultErrorHandler[Bindings any](ctx interfaces.IContext[Bindings], err error) error {
+	return ctx.Status(http.StatusInternalServerError).Text("Internal Server Error")
 }
 
 func New[Bindings any](bindings *Bindings) interfaces.ITakibi[Bindings] {
@@ -49,9 +55,6 @@ func NewWithOption[Bindings any](bindings *Bindings, opt interfaces.TakibiOption
 	return &takibi[Bindings]{
 		env:    bindings,
 		router: router.New[Bindings](),
-		errorHandler: func(ctx interfaces.IContext[Bindings], err error) error {
-			return ctx.Status(http.StatusInternalServerError).Text("Internal Server Error")
-		},
 		blowErrorHandler: func(c interfaces.IContext[Bindings], err error) {
 			fmt.Println(err.Error())
 		},
@@ -221,7 +224,7 @@ func (
 	}
 
 	if err := handler(ctx); err != nil {
-		if err := t.errorHandler(ctx, err); err != nil {
+		if err := t.handleError(ctx, err); err != nil {
 			// fallback
 			ctx.Response().WriteHeader(http.StatusInternalServerError)
 		}
@@ -278,29 +281,6 @@ func (
 	t *takibi[Bindings],
 ) Router() interfaces.IRouter[Bindings] {
 	return t.router
-}
-
-func (
-	t *takibi[Bindings],
-) Route(
-	basePath string,
-	app interfaces.ITakibi[Bindings],
-) error {
-	linearRoutes := app.Router().LinearizeTree()
-	for _, method := range router.SupportedHttpMethod {
-		for _, route := range linearRoutes[method] {
-			fullPath := basePath + route.Path
-
-			if err := t.router.Add(method, fullPath, route.Handler); err != nil {
-				return err
-			}
-
-			if err := t.router.Use(fullPath, route.Middleware...); err != nil {
-				return err
-			}
-		}
-	}
-	return nil
 }
 
 func (

--- a/takibi_test.go
+++ b/takibi_test.go
@@ -2,6 +2,7 @@ package takibi
 
 import (
 	stdContext "context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -242,6 +243,61 @@ func TestTakibi_Router(t *testing.T) {
 		body, err := io.ReadAll(parent.Camp("GET", "/api/who").Raw().Body)
 		assert.Nil(t, err)
 		assert.Equal(t, "parent", string(body))
+	})
+
+	t.Run("errorHandler of sub-app is inherited via Route", func(t *testing.T) {
+		respondWith := func(prefix string) interfaces.ErrorHandlerFunc[any] {
+			return func(c interfaces.IContext[any], err error) error {
+				return c.Status(http.StatusTeapot).Text(prefix + err.Error())
+			}
+		}
+
+		tests := []struct {
+			name       string
+			subOnError interfaces.ErrorHandlerFunc[any]
+			wantBody   string
+		}{
+			{
+				name:       "sub-app errorHandler handles the error",
+				subOnError: respondWith("sub: "),
+				wantBody:   "sub: boom",
+			},
+			{
+				name:       "parent errorHandler is used when sub-app has no OnError",
+				subOnError: nil,
+				wantBody:   "parent: boom",
+			},
+			{
+				name: "error returned by sub-app errorHandler falls back to the parent",
+				subOnError: func(c interfaces.IContext[any], err error) error {
+					return errors.New("sub handler failed")
+				},
+				wantBody: "parent: sub handler failed",
+			},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				sub := newNilApp()
+				if test.subOnError != nil {
+					sub.OnError(test.subOnError)
+				}
+				sub.Get("/boom", func(c interfaces.IContext[any]) error {
+					return errors.New("boom")
+				})
+
+				parent := newNilApp()
+				parent.OnError(respondWith("parent: "))
+				assert.Nil(t, parent.Route("/api", sub))
+
+				resp := parent.Camp("GET", "/api/boom")
+				assert.Equal(t, http.StatusTeapot, resp.StatusCode())
+
+				body, err := io.ReadAll(resp.Raw().Body)
+				assert.Nil(t, err)
+				assert.Equal(t, test.wantBody, string(body))
+			})
+		}
 	})
 
 	t.Run("return error if duplicate when Route", func(t *testing.T) {

--- a/takibi_wasm.go
+++ b/takibi_wasm.go
@@ -16,9 +16,10 @@ import (
 )
 
 type takibi[Bindings any] struct {
-	env              *Bindings
-	cache            sync.Pool
-	router           interfaces.IRouter[Bindings]
+	env    *Bindings
+	cache  sync.Pool
+	router interfaces.IRouter[Bindings]
+	// errorHandler is nil until OnError sets one, see handleError
 	errorHandler     interfaces.ErrorHandlerFunc[Bindings]
 	blowErrorHandler interfaces.BlowErrorHandlerFunc[Bindings]
 	tasks            []interfaces.BlowTask[Bindings]
@@ -26,6 +27,11 @@ type takibi[Bindings any] struct {
 
 	ctx    stdContext.Context
 	cancel stdContext.CancelFunc
+}
+
+// defaultErrorHandler is used until OnError installs one.
+func defaultErrorHandler[Bindings any](ctx interfaces.IContext[Bindings], err error) error {
+	return ctx.Status(http.StatusInternalServerError).Text(err.Error())
 }
 
 func New[Bindings any](bindings *Bindings) interfaces.ITakibi[Bindings] {
@@ -42,9 +48,6 @@ func NewWithOption[Bindings any](bindings *Bindings, opt interfaces.TakibiOption
 	return &takibi[Bindings]{
 		env:    bindings,
 		router: router.New[Bindings](),
-		errorHandler: func(ctx interfaces.IContext[Bindings], err error) error {
-			return ctx.Status(http.StatusInternalServerError).Text(err.Error())
-		},
 		blowErrorHandler: func(c interfaces.IContext[Bindings], err error) {
 			fmt.Println(err.Error())
 		},
@@ -139,7 +142,7 @@ func (
 	}
 
 	if err := handler(ctx); err != nil {
-		if err := t.errorHandler(ctx, err); err != nil {
+		if err := t.handleError(ctx, err); err != nil {
 			// fallback
 			ctx.Response().WriteHeader(http.StatusInternalServerError)
 		}
@@ -196,29 +199,6 @@ func (
 	t *takibi[Bindings],
 ) Router() interfaces.IRouter[Bindings] {
 	return t.router
-}
-
-func (
-	t *takibi[Bindings],
-) Route(
-	basePath string,
-	app interfaces.ITakibi[Bindings],
-) error {
-	linearRoutes := app.Router().LinearizeTree()
-	for _, method := range router.SupportedHttpMethod {
-		for _, route := range linearRoutes[method] {
-			fullPath := basePath + route.Path
-
-			if err := t.router.Add(method, fullPath, route.Handler); err != nil {
-				return err
-			}
-
-			if err := t.router.Use(fullPath, route.Middleware...); err != nil {
-				return err
-			}
-		}
-	}
-	return nil
 }
 
 func (


### PR DESCRIPTION
closes #141

## やったこと

`Route(basePath, app)` はサブアプリのルートとミドルウェアだけを親にコピーしていたため、サブアプリが `OnError` で設定したエラーハンドラは黙って捨てられていた。Hono の `route()` に合わせて、**サブアプリが `OnError` を呼んでいた場合のみ**、サブアプリ由来のハンドラをそのエラーハンドラで包んでから親に登録する。

- サブアプリのエラーハンドラが返したエラーは、Hono と同様さらに親のエラーハンドラへ流れる
- `blowErrorHandler` は引き継がない（`Route` はサブアプリの `tasks` をマージしないため対象が存在しない）
- native / wasm の両方に適用

## デフォルト判定のしかた

Go では関数値を `==` で比較できないので、`errorHandler` を **コンストラクタでは nil のままにし、`OnError` が呼ばれたときだけセット**するようにした。デフォルトはディスパッチ時に `handleError` で適用する。`sub.errorHandler != nil` がそのまま「カスタムされたか」の判定になり、フラグを別に持たずに済む。native と wasm でデフォルトの本文が違う（`"Internal Server Error"` / `err.Error()`）ので、そこは既存挙動のまま各ビルドに残してある。

## ついでに

- 完全に同一だった `Route` の実装を `takibi_native.go` / `takibi_wasm.go` から共有の `route.go` に移動（今回の変更を 2 箇所に書かずに済む）
- `route.Middleware` が空のときは `router.Use` を呼ばないようにした（`Use` は毎回サブツリーを再合成するため、無駄な再合成を省ける）

## docs

- `/docs` の Sub-Routing ページに「errorHandler は引き継ぐ / Bindings と Blow タスクは引き継がない」を追記
- `ITakibi.Route` の doc comment も同様に更新

## 検討したが今回やっていないこと

サブアプリのミドルウェアが返したエラーは、サブアプリのエラーハンドラを経由せず親に届く。ミドルウェアは親の trie に `Use` で登録され、合成時にラップの外側に来るため。単体で動かしたときとマウント後で挙動が変わる点なので気になるなら別途対応したい（エラー境界をミドルウェアとして表現する案がある）が、Issue の方針どおりハンドラのラップに留めた。

## テスト

`just ci` (ut / lint / lint-wasm / build-wasm / fmt) 通過。`Route` のエラーハンドラ継承についてテーブルドリブンで 3 ケース追加。

🤖 Generated with [Claude Code](https://claude.com/claude-code)