### PR TITLE
feat: inject request-scoped Bindings via OnEnv and struct tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,37 @@ func main() {
 }
 ```
 
+## Request-Scoped Bindings
+
+Tag your `Bindings` fields and takibi fills them for every request — you never assemble the env yourself. `env` reads an environment variable (`cloudflare.Getenv` on Workers, `os.Getenv` on a native build), and `cfbinding` reads a Cloudflare binding on Workers while staying at its zero value on a native build, so the same `main()` builds for both targets.
+
+```go
+type Bindings struct {
+	ApiKey string        `env:"API_KEY"`
+	Store  *kv.Namespace `cfbinding:"MY_KV"`
+}
+
+// no resolver to register: takibi.New detects the tags
+app := takibi.New(&Bindings{})
+
+app.Get("/secret", func(ctx MyContext) error {
+	return ctx.Text(ctx.Env().ApiKey) // resolved for this request
+})
+```
+
+For values derived from the request itself, register your own resolver with `OnEnv`. It replaces the tag resolver entirely.
+
+```go
+app.OnEnv(func(r *http.Request) *Bindings {
+	return &Bindings{
+		ApiKey:    os.Getenv("API_KEY"),
+		RequestID: r.Header.Get("X-Request-Id"),
+	}
+})
+```
+
+Without any tag and without `OnEnv`, every request shares the single `Bindings` pointer passed to `takibi.New`, so writing to `ctx.Env()` from a handler is a data race across concurrent requests.
+
 ## Safe Redirect
 
 `ctx.Redirect()` only accepts relative paths. For redirecting to external hosts, use `ctx.RedirectExternal()` with an explicit allowlist.

--- a/_templates/cloudflare-worker/main.go
+++ b/_templates/cloudflare-worker/main.go
@@ -7,7 +7,13 @@ import (
 	"cloudflare-worker/templates/pages"
 )
 
-type Bindings struct{}
+// Bindings is filled per request: takibi injects the tagged fields for you.
+// `env` reads a wrangler.jsonc var / secret on Workers and os.Getenv on a
+// native build, so the same main() works for both targets. See the
+// cloudflareenv package for the `cfbinding` tag (KV, R2, ...).
+type Bindings struct {
+	Greeting string `env:"GREETING"`
+}
 
 type MyContext = interfaces.IContext[Bindings]
 
@@ -18,6 +24,10 @@ func main() {
 		return ctx.Render(&interfaces.RenderConfig{
 			Component: pages.Index(),
 		})
+	})
+
+	app.Get("/greeting", func(ctx MyContext) error {
+		return ctx.Text(ctx.Env().Greeting) // 100% string
 	})
 
 	app.Fire("")

--- a/_templates/cloudflare-worker/wrangler.jsonc
+++ b/_templates/cloudflare-worker/wrangler.jsonc
@@ -12,11 +12,13 @@
 	},
 	"compatibility_flags": [
 		"nodejs_compat"
-	]
+	],
+	"vars": {
+		"GREETING": "hello from takibi"
+	}
 	/**
 	 * Bindings
 	 * https://developers.cloudflare.com/workers/runtime-apis/bindings/
 	 */
-	// "vars": { "MY_VARIABLE": "production_value" }
 	// "kv_namespaces": [{ "binding": "MY_KV", "id": "<KV_NAMESPACE_ID>" }]
 }

--- a/cloudflareenv/binding_native.go
+++ b/cloudflareenv/binding_native.go
@@ -1,0 +1,16 @@
+//go:build !wasm
+
+package cloudflareenv
+
+import (
+	"os"
+	"reflect"
+)
+
+func lookupEnv(name string) string {
+	return os.Getenv(name)
+}
+
+// assignBinding is a no-op on native: Cloudflare bindings only exist on the
+// Workers runtime, so a `cfbinding` field keeps its zero value.
+func assignBinding(_ reflect.Value, _ string) {}

--- a/cloudflareenv/binding_wasm.go
+++ b/cloudflareenv/binding_wasm.go
@@ -1,0 +1,40 @@
+//go:build wasm
+
+package cloudflareenv
+
+import (
+	"reflect"
+	"syscall/js"
+
+	"github.com/syumai/workers/cloudflare"
+	"github.com/syumai/workers/cloudflare/kv"
+	"github.com/syumai/workers/cloudflare/r2"
+)
+
+func lookupEnv(name string) string {
+	return cloudflare.Getenv(name)
+}
+
+var (
+	kvNamespaceType = reflect.TypeFor[*kv.Namespace]()
+	r2BucketType    = reflect.TypeFor[*r2.Bucket]()
+	jsValueType     = reflect.TypeFor[js.Value]()
+)
+
+// assignBinding fills field with the Cloudflare binding named name.
+// Supported field types are *kv.Namespace, *r2.Bucket and js.Value; any other
+// type — or a binding missing from wrangler.jsonc — leaves the zero value.
+func assignBinding(field reflect.Value, name string) {
+	switch field.Type() {
+	case kvNamespaceType:
+		if namespace, err := kv.NewNamespace(name); err == nil {
+			field.Set(reflect.ValueOf(namespace))
+		}
+	case r2BucketType:
+		if bucket, err := r2.NewBucket(name); err == nil {
+			field.Set(reflect.ValueOf(bucket))
+		}
+	case jsValueType:
+		field.Set(reflect.ValueOf(cloudflare.GetBinding(name)))
+	}
+}

--- a/cloudflareenv/resolver.go
+++ b/cloudflareenv/resolver.go
@@ -1,0 +1,106 @@
+// Package cloudflareenv builds request-scoped Bindings from struct tags.
+//
+// A field tagged with `env:"NAME"` receives the value of the environment
+// variable NAME — cloudflare.Getenv on wasm, os.Getenv on native. A field
+// tagged with `cfbinding:"NAME"` receives the Cloudflare binding NAME on
+// wasm and is left at its zero value on native, so the same main() builds
+// for both targets.
+//
+//	type Bindings struct {
+//		ApiKey string        `env:"API_KEY"`
+//		Store  *kv.Namespace `cfbinding:"MY_KV"`
+//	}
+//
+// takibi.New wires the resolver automatically when Bindings has any tagged
+// field; call Resolver directly only to compose it with your own logic.
+package cloudflareenv
+
+import (
+	"fmt"
+	"net/http"
+	"reflect"
+
+	"github.com/poteto0/takibi/interfaces"
+)
+
+const (
+	envTag       = "env"
+	cfBindingTag = "cfbinding"
+)
+
+// fieldPlan describes one tagged field, resolved once at startup.
+type fieldPlan struct {
+	index int
+	// name is the environment variable name, or the Cloudflare binding name
+	// when binding is true.
+	name    string
+	binding bool
+}
+
+// buildPlan collects the tagged fields of typ. A non-struct typ has no
+// taggable field and yields an empty plan.
+func buildPlan(typ reflect.Type) ([]fieldPlan, error) {
+	if typ.Kind() != reflect.Struct {
+		return nil, nil
+	}
+
+	var plan []fieldPlan
+
+	for i := range typ.NumField() {
+		field := typ.Field(i)
+		envName, hasEnv := field.Tag.Lookup(envTag)
+		bindingName, hasBinding := field.Tag.Lookup(cfBindingTag)
+
+		switch {
+		case !hasEnv && !hasBinding:
+			continue
+		case hasEnv && hasBinding:
+			return nil, fmt.Errorf("cloudflareenv: field %q: env and cfbinding tags are mutually exclusive", field.Name)
+		case !field.IsExported():
+			return nil, fmt.Errorf("cloudflareenv: field %q: tagged field must be exported", field.Name)
+		case hasEnv && field.Type.Kind() != reflect.String:
+			return nil, fmt.Errorf("cloudflareenv: field %q: env tag requires a string field, got %s", field.Name, field.Type)
+		}
+
+		if hasEnv {
+			plan = append(plan, fieldPlan{index: i, name: envName})
+			continue
+		}
+		plan = append(plan, fieldPlan{index: i, name: bindingName, binding: true})
+	}
+
+	return plan, nil
+}
+
+// Resolver returns a resolver that copies base and fills its tagged fields on
+// every request. It returns a nil resolver when Bindings has no tagged field,
+// so the caller can keep the app-wide Bindings as is.
+func Resolver[Bindings any](base *Bindings) (interfaces.EnvResolverFunc[Bindings], error) {
+	plan, err := buildPlan(reflect.TypeFor[Bindings]())
+	if err != nil {
+		return nil, err
+	}
+	if len(plan) == 0 {
+		return nil, nil
+	}
+
+	if base == nil {
+		base = new(Bindings)
+	}
+
+	return func(_ *http.Request) *Bindings {
+		bindings := *base
+		value := reflect.ValueOf(&bindings).Elem()
+
+		for _, f := range plan {
+			field := value.Field(f.index)
+			if f.binding {
+				assignBinding(field, f.name)
+				continue
+			}
+			field.SetString(lookupEnv(f.name))
+		}
+
+		return &bindings
+	}, nil
+}

--- a/cloudflareenv/resolver_test.go
+++ b/cloudflareenv/resolver_test.go
@@ -1,0 +1,146 @@
+package cloudflareenv
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type unsupportedBinding struct{ Ptr *int }
+
+func TestBuildPlan(t *testing.T) {
+	tests := []struct {
+		name    string
+		typ     any
+		want    []fieldPlan
+		wantErr string
+	}{
+		{
+			name: "no tag",
+			typ:  struct{ Foo string }{},
+			want: nil,
+		},
+		{
+			name: "non struct type",
+			typ:  "not a struct",
+			want: nil,
+		},
+		{
+			name: "env and cfbinding tags",
+			typ: struct {
+				ApiKey string `env:"API_KEY"`
+				Plain  string
+				Store  unsupportedBinding `cfbinding:"MY_KV"`
+			}{},
+			want: []fieldPlan{
+				{index: 0, name: "API_KEY"},
+				{index: 2, name: "MY_KV", binding: true},
+			},
+		},
+		{
+			name: "env tag on non-string field",
+			typ: struct {
+				Port int `env:"PORT"`
+			}{},
+			wantErr: `cloudflareenv: field "Port": env tag requires a string field, got int`,
+		},
+		{
+			name: "both tags on one field",
+			typ: struct {
+				Foo string `env:"FOO" cfbinding:"FOO"`
+			}{},
+			wantErr: `cloudflareenv: field "Foo": env and cfbinding tags are mutually exclusive`,
+		},
+		{
+			name: "unexported tagged field",
+			typ: struct {
+				foo string `env:"FOO"`
+			}{},
+			wantErr: `cloudflareenv: field "foo": tagged field must be exported`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := buildPlan(reflect.TypeOf(tt.typ))
+			if tt.wantErr != "" {
+				assert.EqualError(t, err, tt.wantErr)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestResolver(t *testing.T) {
+	t.Run("returns nil when Bindings has no tag", func(t *testing.T) {
+		type Bindings struct{ Foo string }
+
+		resolver, err := Resolver(&Bindings{Foo: "bar"})
+
+		assert.NoError(t, err)
+		assert.Nil(t, resolver)
+	})
+
+	t.Run("returns the plan error", func(t *testing.T) {
+		type Bindings struct {
+			Port int `env:"PORT"`
+		}
+
+		resolver, err := Resolver(&Bindings{})
+
+		assert.Error(t, err)
+		assert.Nil(t, resolver)
+	})
+
+	t.Run("fills tagged fields per request and keeps untagged ones", func(t *testing.T) {
+		type Bindings struct {
+			ApiKey string `env:"API_KEY"`
+			Greet  func() string
+		}
+
+		base := &Bindings{Greet: func() string { return "hello" }}
+		resolver, err := Resolver(base)
+		assert.NoError(t, err)
+
+		t.Setenv("API_KEY", "first")
+		got1 := resolver(httptest.NewRequest(http.MethodGet, "/", nil))
+		t.Setenv("API_KEY", "second")
+		got2 := resolver(httptest.NewRequest(http.MethodGet, "/", nil))
+
+		assert.Equal(t, "first", got1.ApiKey)
+		assert.Equal(t, "second", got2.ApiKey)
+		assert.NotSame(t, got1, got2)
+		assert.Equal(t, "", base.ApiKey)
+		assert.Equal(t, "hello", got1.Greet())
+	})
+
+	t.Run("cfbinding fields stay zero on native", func(t *testing.T) {
+		type Bindings struct {
+			Store unsupportedBinding `cfbinding:"MY_KV"`
+		}
+
+		resolver, err := Resolver(&Bindings{})
+		assert.NoError(t, err)
+
+		got := resolver(httptest.NewRequest(http.MethodGet, "/", nil))
+
+		assert.Nil(t, got.Store.Ptr)
+	})
+
+	t.Run("accepts a nil base", func(t *testing.T) {
+		type Bindings struct {
+			ApiKey string `env:"API_KEY"`
+		}
+
+		resolver, err := Resolver[Bindings](nil)
+		assert.NoError(t, err)
+
+		t.Setenv("API_KEY", "value")
+		assert.Equal(t, "value", resolver(httptest.NewRequest(http.MethodGet, "/", nil)).ApiKey)
+	})
+}

--- a/context.go
+++ b/context.go
@@ -49,6 +49,10 @@ func (c *context[Bindings]) Env() *Bindings {
 	return c.env
 }
 
+func (c *context[Bindings]) SetEnv(env *Bindings) {
+	c.env = env
+}
+
 func (c *context[Bindings]) Response() http.ResponseWriter {
 	return c.response
 }

--- a/context_test.go
+++ b/context_test.go
@@ -333,3 +333,14 @@ func TestContext_Validated(t *testing.T) {
 		assert.False(t, ok)
 	})
 }
+
+func TestContext_SetEnv(t *testing.T) {
+	type Bindings struct{ Foo string }
+
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	ctx := NewContext(httptest.NewRecorder(), r, &Bindings{Foo: "first"}, nil)
+
+	ctx.SetEnv(&Bindings{Foo: "second"})
+
+	assert.Equal(t, "second", ctx.Env().Foo)
+}

--- a/docs/templates/code/cloudflareenvonenvgo.templ
+++ b/docs/templates/code/cloudflareenvonenvgo.templ
@@ -1,0 +1,16 @@
+package code
+
+templ Cloudflareenvonenvgo() {
+	@templ.Raw(
+		`
+			<pre class="chroma"><code><span class="c1">// OnEnv replaces the tag resolver: it runs once per request and</span>
+<span class="c1">// its result becomes ctx.Env() for that request only.</span>
+<span class="nx">app</span><span class="p">.</span><span class="nf">OnEnv</span><span class="p">(</span><span class="kd">func</span><span class="p">(</span><span class="nx">r</span> <span class="o">*</span><span class="nx">http</span><span class="p">.</span><span class="nx">Request</span><span class="p">)</span> <span class="o">*</span><span class="nx">Bindings</span> <span class="p">&#123;</span>
+	<span class="k">return</span> <span class="o">&amp;</span><span class="nx">Bindings</span><span class="p">&#123;</span>
+		<span class="nx">ApiKey</span><span class="p">:</span>    <span class="nx">os</span><span class="p">.</span><span class="nf">Getenv</span><span class="p">(</span><span class="s">&#34;API_KEY&#34;</span><span class="p">)</span><span class="p">,</span>
+		<span class="nx">RequestID</span><span class="p">:</span> <span class="nx">r</span><span class="p">.</span><span class="nx">Header</span><span class="p">.</span><span class="nf">Get</span><span class="p">(</span><span class="s">&#34;X-Request-Id&#34;</span><span class="p">)</span><span class="p">,</span>
+	<span class="p">&#125;</span>
+<span class="p">&#125;</span><span class="p">)</span></code></pre>
+		`,
+	)
+}

--- a/docs/templates/code/cloudflareworkerbindingsgo.templ
+++ b/docs/templates/code/cloudflareworkerbindingsgo.templ
@@ -4,12 +4,17 @@ templ Cloudflareworkerbindingsgo() {
 	@templ.Raw(
 		`
 			<pre class="chroma"><code><span class="kd">type</span> <span class="nx">Bindings</span> <span class="kd">struct</span> <span class="p">&#123;</span>
-	<span class="nx">MyKV</span>   <span class="nx">workers</span><span class="p">.</span><span class="nx">KVNamespace</span>
-	<span class="nx">Secret</span> <span class="kt">string</span>
+	<span class="c1">// wasm: cloudflare.Getenv(&#34;API_KEY&#34;) / native: os.Getenv(&#34;API_KEY&#34;)</span>
+	<span class="nx">ApiKey</span> <span class="kt">string</span> <span class="s">&#96;</span><span class="s">env:&#34;API_KEY&#34;</span><span class="s">&#96;</span>
+	<span class="c1">// wasm: the MY_KV binding / native: left nil</span>
+	<span class="nx">Store</span> <span class="o">*</span><span class="nx">kv</span><span class="p">.</span><span class="nx">Namespace</span> <span class="s">&#96;</span><span class="s">cfbinding:&#34;MY_KV&#34;</span><span class="s">&#96;</span>
 <span class="p">&#125;</span>
 
+<span class="c1">// no resolver to register: takibi.New detects the tags</span>
+<span class="nx">app</span> <span class="o">:=</span> <span class="nx">takibi</span><span class="p">.</span><span class="nf">New</span><span class="p">(</span><span class="o">&amp;</span><span class="nx">Bindings</span><span class="p">&#123;</span><span class="p">&#125;</span><span class="p">)</span>
+
 <span class="nx">app</span><span class="p">.</span><span class="nf">Get</span><span class="p">(</span><span class="s">&#34;/secret&#34;</span><span class="p">,</span> <span class="kd">func</span><span class="p">(</span><span class="nx">ctx</span> <span class="nx">MyContext</span><span class="p">)</span> <span class="kt">error</span> <span class="p">&#123;</span>
-	<span class="k">return</span> <span class="nx">ctx</span><span class="p">.</span><span class="nf">Text</span><span class="p">(</span><span class="nx">ctx</span><span class="p">.</span><span class="nf">Env</span><span class="p">(</span><span class="p">)</span><span class="p">.</span><span class="nx">Secret</span><span class="p">)</span> <span class="c1">// 100% type-safe</span>
+	<span class="k">return</span> <span class="nx">ctx</span><span class="p">.</span><span class="nf">Text</span><span class="p">(</span><span class="nx">ctx</span><span class="p">.</span><span class="nf">Env</span><span class="p">(</span><span class="p">)</span><span class="p">.</span><span class="nx">ApiKey</span><span class="p">)</span> <span class="c1">// 100% type-safe, resolved per request</span>
 <span class="p">&#125;</span><span class="p">)</span></code></pre>
 		`,
 	)

--- a/docs/templates/code/cloudflareworkerwranglerjsonc.templ
+++ b/docs/templates/code/cloudflareworkerwranglerjsonc.templ
@@ -3,8 +3,8 @@ package code
 templ Cloudflareworkerwranglerjsonc() {
 	@templ.Raw(
 		`
-			<pre class="chroma"><span style="position:absolute;top:10px;right:14px;font-size:11px;color:#475569;font-family:sans-serif;text-transform:uppercase;letter-spacing:0.05em;">jsonc</span><code><span class="s2">&#34;kv_namespaces&#34;</span><span class="err">:</span> <span class="p">[</span><span class="p">&#123;</span> <span class="nt">&#34;binding&#34;</span><span class="p">:</span> <span class="s2">&#34;MyKV&#34;</span><span class="p">,</span> <span class="nt">&#34;id&#34;</span><span class="p">:</span> <span class="s2">&#34;&lt;KV_NAMESPACE_ID&gt;&#34;</span> <span class="p">&#125;</span><span class="p">]</span><span class="err">,</span>
-<span class="s2">&#34;vars&#34;</span><span class="err">:</span> <span class="p">&#123;</span> <span class="nt">&#34;Secret&#34;</span><span class="p">:</span> <span class="s2">&#34;my-secret-value&#34;</span> <span class="p">&#125;</span></code></pre>
+			<pre class="chroma"><span style="position:absolute;top:10px;right:14px;font-size:11px;color:#475569;font-family:sans-serif;text-transform:uppercase;letter-spacing:0.05em;">jsonc</span><code><span class="s2">&#34;kv_namespaces&#34;</span><span class="err">:</span> <span class="p">[</span><span class="p">&#123;</span> <span class="nt">&#34;binding&#34;</span><span class="p">:</span> <span class="s2">&#34;MY_KV&#34;</span><span class="p">,</span> <span class="nt">&#34;id&#34;</span><span class="p">:</span> <span class="s2">&#34;&lt;KV_NAMESPACE_ID&gt;&#34;</span> <span class="p">&#125;</span><span class="p">]</span><span class="err">,</span>
+<span class="s2">&#34;vars&#34;</span><span class="err">:</span> <span class="p">&#123;</span> <span class="nt">&#34;API_KEY&#34;</span><span class="p">:</span> <span class="s2">&#34;my-secret-value&#34;</span> <span class="p">&#125;</span></code></pre>
 		`,
 	)
 }

--- a/docs/templates/code/typesafecontextcfgo.templ
+++ b/docs/templates/code/typesafecontextcfgo.templ
@@ -4,11 +4,11 @@ templ Typesafecontextcfgo() {
 	@templ.Raw(
 		`
 			<pre class="chroma"><code><span class="kd">type</span> <span class="nx">Bindings</span> <span class="kd">struct</span> <span class="p">&#123;</span>
-	<span class="nx">MyKV</span>   <span class="nx">workers</span><span class="p">.</span><span class="nx">KVNamespace</span>
-	<span class="nx">Secret</span> <span class="kt">string</span>
+	<span class="nx">Store</span>  <span class="o">*</span><span class="nx">kv</span><span class="p">.</span><span class="nx">Namespace</span> <span class="s">&#96;</span><span class="s">cfbinding:&#34;MY_KV&#34;</span><span class="s">&#96;</span>
+	<span class="nx">ApiKey</span> <span class="kt">string</span>        <span class="s">&#96;</span><span class="s">env:&#34;API_KEY&#34;</span><span class="s">&#96;</span>
 <span class="p">&#125;</span>
 
-<span class="c1">// ctx.Env().MyKV is the Workers KV binding — typed, always.</span></code></pre>
+<span class="c1">// takibi resolves both fields per request — typed, always.</span></code></pre>
 		`,
 	)
 }

--- a/docs/templates/pages/cloudflare_worker.templ
+++ b/docs/templates/pages/cloudflare_worker.templ
@@ -50,8 +50,35 @@ templ CloudflareWorker() {
 	<h2>Application Code</h2>
 	@code.Cloudflareworkergo()
 	<h2>Workers Bindings Like Hono</h2>
-	<p>Add Cloudflare environment bindings (KV, secrets, etc.) to your <code>Bindings</code> struct for type-safe access:</p>
+	<p>
+		Tag the fields of your <code>Bindings</code> struct and takibi fills them for every request &#8212; you never assemble the env yourself.
+		<code>env</code> reads an environment variable (<code>cloudflare.Getenv</code> on Workers, <code>os.Getenv</code> on a native build) and
+		<code>cfbinding</code> reads a Cloudflare binding such as a KV namespace or an R2 bucket.
+	</p>
 	@code.Cloudflareworkerbindingsgo()
 	<p>Declare the same bindings in <code>wrangler.jsonc</code>:</p>
 	@code.Cloudflareworkerwranglerjsonc()
+	<div class={ styles.Callout() }>
+		A <code>cfbinding</code> field is left at its zero value on a native build, so the same <code>main()</code> compiles and runs for both targets.
+		Supported field types on Workers are <code>*kv.Namespace</code>, <code>*r2.Bucket</code> and <code>js.Value</code>.
+	</div>
+	<h2>Custom Resolvers</h2>
+	<p>
+		When a tag is not enough &#8212; per-request values derived from the request itself, for instance &#8212; register your own resolver with <code>OnEnv</code>.
+		It replaces the tag resolver entirely.
+	</p>
+	@code.Cloudflareenvonenvgo()
+	<h2>Current Limitations</h2>
+	<ul style="padding-left:20px;margin-top:8px;display:flex;flex-direction:column;gap:6px;">
+		<li>
+			Without any tag and without <code>OnEnv</code>, every request shares the single <code>Bindings</code> pointer passed to
+			<code>takibi.New</code>. Writing to <code>ctx.Env()</code> from a handler is then a data race across concurrent requests.
+		</li>
+		<li>
+			<code>takibi.New[Bindings](nil)</code> allocates a zero-valued <code>Bindings</code>; untagged fields stay zero rather than being resolved.
+		</li>
+		<li>
+			A sub app registered with <code>app.Route</code> discards its own <code>Bindings</code>: <code>ctx.Env()</code> always returns the parent&#39;s.
+		</li>
+	</ul>
 }

--- a/env.go
+++ b/env.go
@@ -1,0 +1,73 @@
+package takibi
+
+import (
+	"net/http"
+
+	"github.com/poteto0/takibi/cloudflareenv"
+	"github.com/poteto0/takibi/interfaces"
+)
+
+// defaultEnvResolver returns the struct-tag resolver for Bindings, or nil when
+// Bindings carries no `env` / `cfbinding` tag. An invalid tag is a programming
+// error, so it panics at app construction rather than on the first request.
+func defaultEnvResolver[Bindings any](bindings *Bindings) interfaces.EnvResolverFunc[Bindings] {
+	resolver, err := cloudflareenv.Resolver(bindings)
+	if err != nil {
+		panic(err)
+	}
+	return resolver
+}
+
+// OnEnv registers a resolver invoked once per request to build ctx.Env().
+func (
+	t *takibi[Bindings],
+) OnEnv(
+	resolver interfaces.EnvResolverFunc[Bindings],
+) {
+	t.envResolver = resolver
+}
+
+// resolveEnv builds the Bindings for one request or one Blow task. Without a
+// resolver every caller shares the app-wide Bindings, as before.
+func (
+	t *takibi[Bindings],
+) resolveEnv(
+	r *http.Request,
+) *Bindings {
+	if t.envResolver == nil {
+		return t.env
+	}
+	return t.envResolver(r)
+}
+
+// initializeContext takes a context out of the pool (or builds a new one) and
+// gives it this request's env. The env is always re-assigned so a pooled
+// context never carries the previous request's Bindings.
+func (
+	t *takibi[Bindings],
+) initializeContext(
+	w http.ResponseWriter,
+	r *http.Request,
+) interfaces.IContext[Bindings] {
+	env := t.resolveEnv(r)
+
+	ctx, ok := t.cache.Get().(interfaces.IContext[Bindings])
+	if !ok {
+		return NewContext(w, r, env, &t.option)
+	}
+
+	ctx.Reset(w, r)
+	ctx.SetEnv(env)
+	return ctx
+}
+
+// newTaskContext builds the context handed to a Blow task. Like a request, a
+// task gets its env from the resolver, so tagged Bindings are populated there
+// too.
+func (
+	t *takibi[Bindings],
+) newTaskContext(
+	r *http.Request,
+) interfaces.IContext[Bindings] {
+	return NewContext(nil, r, t.resolveEnv(r), &t.option)
+}

--- a/env_test.go
+++ b/env_test.go
@@ -1,0 +1,134 @@
+package takibi
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/poteto0/takibi/interfaces"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTakibi_OnEnv(t *testing.T) {
+	type Bindings struct{ Foo string }
+
+	t.Run("resolver is called per request", func(t *testing.T) {
+		app := New[Bindings](nil)
+		called := 0
+		app.OnEnv(func(r *http.Request) *Bindings {
+			called++
+			return &Bindings{Foo: r.URL.Path}
+		})
+
+		seen := make([]string, 0, 2)
+		_ = app.Get("/a", func(ctx interfaces.IContext[Bindings]) error {
+			seen = append(seen, ctx.Env().Foo)
+			return ctx.Text("ok")
+		})
+		_ = app.Get("/b", func(ctx interfaces.IContext[Bindings]) error {
+			seen = append(seen, ctx.Env().Foo)
+			return ctx.Text("ok")
+		})
+
+		// two sequential requests go through the sync.Pool reuse path
+		app.Camp(http.MethodGet, "/a")
+		app.Camp(http.MethodGet, "/b")
+
+		assert.Equal(t, 2, called)
+		assert.Equal(t, []string{"/a", "/b"}, seen)
+	})
+
+	t.Run("without resolver the app env is kept", func(t *testing.T) {
+		app := New(&Bindings{Foo: "fixed"})
+
+		seen := make([]string, 0, 2)
+		_ = app.Get("/", func(ctx interfaces.IContext[Bindings]) error {
+			seen = append(seen, ctx.Env().Foo)
+			return ctx.Text("ok")
+		})
+
+		app.Camp(http.MethodGet, "/")
+		app.Camp(http.MethodGet, "/")
+
+		assert.Equal(t, []string{"fixed", "fixed"}, seen)
+	})
+
+	t.Run("pooled context does not leak the previous env", func(t *testing.T) {
+		app := New(&Bindings{Foo: "fixed"}).(*takibi[Bindings])
+
+		r1 := httptest.NewRequest(http.MethodGet, "/", nil)
+		ctx1 := app.initializeContext(httptest.NewRecorder(), r1)
+		ctx1.SetEnv(&Bindings{Foo: "leaked"})
+		app.cache.Put(ctx1)
+
+		r2 := httptest.NewRequest(http.MethodGet, "/", nil)
+		ctx2 := app.initializeContext(httptest.NewRecorder(), r2)
+
+		assert.Equal(t, "fixed", ctx2.Env().Foo)
+	})
+}
+
+func TestTakibi_TaggedBindings(t *testing.T) {
+	t.Run("tagged fields are injected per request without OnEnv", func(t *testing.T) {
+		type Bindings struct {
+			ApiKey string `env:"TAKIBI_TEST_API_KEY"`
+			Prefix string
+		}
+
+		app := New(&Bindings{Prefix: "kept"})
+		seen := make([]string, 0, 2)
+		_ = app.Get("/", func(ctx interfaces.IContext[Bindings]) error {
+			seen = append(seen, ctx.Env().Prefix+":"+ctx.Env().ApiKey)
+			return ctx.Text("ok")
+		})
+
+		t.Setenv("TAKIBI_TEST_API_KEY", "first")
+		app.Camp(http.MethodGet, "/")
+		t.Setenv("TAKIBI_TEST_API_KEY", "second")
+		app.Camp(http.MethodGet, "/")
+
+		assert.Equal(t, []string{"kept:first", "kept:second"}, seen)
+	})
+
+	t.Run("OnEnv overrides the tag resolver", func(t *testing.T) {
+		type Bindings struct {
+			ApiKey string `env:"TAKIBI_TEST_API_KEY"`
+		}
+
+		app := New[Bindings](nil)
+		app.OnEnv(func(_ *http.Request) *Bindings {
+			return &Bindings{ApiKey: "custom"}
+		})
+		seen := ""
+		_ = app.Get("/", func(ctx interfaces.IContext[Bindings]) error {
+			seen = ctx.Env().ApiKey
+			return ctx.Text("ok")
+		})
+
+		t.Setenv("TAKIBI_TEST_API_KEY", "from-env")
+		app.Camp(http.MethodGet, "/")
+
+		assert.Equal(t, "custom", seen)
+	})
+
+	t.Run("an invalid tag panics at construction", func(t *testing.T) {
+		type Bindings struct {
+			Port int `env:"PORT"`
+		}
+
+		assert.Panics(t, func() { New[Bindings](nil) })
+	})
+}
+
+func TestTakibi_NewTaskContext(t *testing.T) {
+	type Bindings struct {
+		ApiKey string `env:"TAKIBI_TEST_API_KEY"`
+	}
+
+	t.Setenv("TAKIBI_TEST_API_KEY", "resolved")
+	app := New[Bindings](nil).(*takibi[Bindings])
+
+	c := app.newTaskContext(httptest.NewRequest(http.MethodGet, "/", nil))
+
+	assert.Equal(t, "resolved", c.Env().ApiKey)
+}

--- a/interfaces/handler.go
+++ b/interfaces/handler.go
@@ -1,6 +1,11 @@
 package interfaces
 
+import "net/http"
+
 type HandlerFunc[Bindings any] = func(ctx IContext[Bindings]) error
 type MiddlewareFunc[Bindings any] func(c IContext[Bindings], next HandlerFunc[Bindings]) error
 type ErrorHandlerFunc[Bindings any] func(ctx IContext[Bindings], err error) error
 type BlowErrorHandlerFunc[Bindings any] func(c IContext[Bindings], err error)
+
+// EnvResolverFunc builds the Bindings exposed to ctx.Env() for a single request.
+type EnvResolverFunc[Bindings any] func(r *http.Request) *Bindings

--- a/interfaces/icontext.go
+++ b/interfaces/icontext.go
@@ -6,6 +6,13 @@ import (
 
 type IContext[Bindings any] interface {
 	Env() *Bindings
+
+	// SetEnv replaces the Bindings exposed by Env.
+	// It is called once per request when an EnvResolverFunc is registered
+	// via ITakibi.OnEnv, so a pooled context never carries the previous
+	// request's env.
+	SetEnv(env *Bindings)
+
 	Req() IRequest
 	Response() http.ResponseWriter
 	Reset(w http.ResponseWriter, r *http.Request)

--- a/interfaces/itakibi.go
+++ b/interfaces/itakibi.go
@@ -25,6 +25,15 @@ type ITakibi[Bindings any] interface {
 
 	OnError(handler ErrorHandlerFunc[Bindings])
 
+	// OnEnv registers a resolver invoked once per request to build the
+	// Bindings returned by ctx.Env(). Without it, every request shares the
+	// Bindings passed to New.
+	//
+	//  app.OnEnv(func(r *http.Request) *Bindings {
+	//   return &Bindings{ApiKey: os.Getenv("API_KEY")}
+	//  })
+	OnEnv(resolver EnvResolverFunc[Bindings])
+
 	// OnBlowError sets the handler invoked when a Blow task returns an error.
 	//	- on wasm: applies to "schedule" tasks dispatched by Cron Triggers.
 	OnBlowError(handler BlowErrorHandlerFunc[Bindings])
@@ -43,8 +52,9 @@ type ITakibi[Bindings any] interface {
 	//
 	// then, GET /api/users will return "users"
 	//
-	//	- ! the sub app's Bindings are discarded: ctx.Env() always returns
-	//	  the parent's Bindings, so pass every binding to the parent app.
+	//	- ! the sub app's Bindings and its OnEnv resolver are discarded:
+	//	  ctx.Env() always returns the parent's Bindings, so pass every
+	//	  binding to the parent app.
 	Route(basePath string, app ITakibi[Bindings]) error
 
 	/* add node */

--- a/takibi_native.go
+++ b/takibi_native.go
@@ -24,6 +24,7 @@ type takibi[Bindings any] struct {
 	router           interfaces.IRouter[Bindings]
 	errorHandler     interfaces.ErrorHandlerFunc[Bindings]
 	blowErrorHandler interfaces.BlowErrorHandlerFunc[Bindings]
+	envResolver      interfaces.EnvResolverFunc[Bindings]
 	tasks            []interfaces.BlowTask[Bindings]
 	cron             *cron.Cron
 	option           interfaces.TakibiOption
@@ -47,8 +48,9 @@ func NewWithOption[Bindings any](bindings *Bindings, opt interfaces.TakibiOption
 	ctx, cancel := stdContext.WithCancel(stdContext.Background())
 
 	return &takibi[Bindings]{
-		env:    bindings,
-		router: router.New[Bindings](),
+		env:         bindings,
+		envResolver: defaultEnvResolver(bindings),
+		router:      router.New[Bindings](),
 		errorHandler: func(ctx interfaces.IContext[Bindings], err error) error {
 			return ctx.Status(http.StatusInternalServerError).Text("Internal Server Error")
 		},
@@ -91,7 +93,7 @@ func (
 	for _, task := range t.tasks {
 		if task.BlowActionTag == interfaces.BlowTagTrigger && task.BlowActionTrigger == interfaces.BlowTriggerStart {
 			r, _ := http.NewRequestWithContext(t.ctx, "GET", "/", nil)
-			c := NewContext(nil, r, t.env, &t.option)
+			c := t.newTaskContext(r)
 			go func(task interfaces.BlowTask[Bindings]) {
 				if err := task.BlowAction(c); err != nil {
 					t.blowErrorHandler(c, err)
@@ -105,7 +107,7 @@ func (
 			}
 			_, _ = t.cron.AddFunc(task.BlowActionSchedule, func() {
 				r, _ := http.NewRequestWithContext(t.ctx, "GET", "/", nil)
-				c := NewContext(nil, r, t.env, &t.option)
+				c := t.newTaskContext(r)
 				if err := task.BlowAction(c); err != nil {
 					t.blowErrorHandler(c, err)
 				}
@@ -153,7 +155,7 @@ func (
 			go func(task interfaces.BlowTask[Bindings]) {
 				defer wg.Done()
 				r, _ := http.NewRequestWithContext(ctx, "GET", "/", nil)
-				c := NewContext(nil, r, t.env, &t.option)
+				c := t.newTaskContext(r)
 				if err := task.BlowAction(c); err != nil {
 					t.blowErrorHandler(c, err)
 				}
@@ -227,20 +229,6 @@ func (
 		}
 		return
 	}
-}
-
-func (
-	t *takibi[Bindings],
-) initializeContext(
-	w http.ResponseWriter,
-	r *http.Request,
-) interfaces.IContext[Bindings] {
-	if ctx, ok := t.cache.Get().(interfaces.IContext[Bindings]); ok {
-		ctx.Reset(w, r)
-		return ctx
-	}
-
-	return NewContext(w, r, t.Env(), &t.option)
 }
 
 func (

--- a/takibi_wasm.go
+++ b/takibi_wasm.go
@@ -21,6 +21,7 @@ type takibi[Bindings any] struct {
 	router           interfaces.IRouter[Bindings]
 	errorHandler     interfaces.ErrorHandlerFunc[Bindings]
 	blowErrorHandler interfaces.BlowErrorHandlerFunc[Bindings]
+	envResolver      interfaces.EnvResolverFunc[Bindings]
 	tasks            []interfaces.BlowTask[Bindings]
 	option           interfaces.TakibiOption
 
@@ -40,8 +41,9 @@ func NewWithOption[Bindings any](bindings *Bindings, opt interfaces.TakibiOption
 	ctx, cancel := stdContext.WithCancel(stdContext.Background())
 
 	return &takibi[Bindings]{
-		env:    bindings,
-		router: router.New[Bindings](),
+		env:         bindings,
+		envResolver: defaultEnvResolver(bindings),
+		router:      router.New[Bindings](),
 		errorHandler: func(ctx interfaces.IContext[Bindings], err error) error {
 			return ctx.Status(http.StatusInternalServerError).Text(err.Error())
 		},
@@ -86,7 +88,7 @@ func (
 	cron.ScheduleTaskNonBlock(func(ctx stdContext.Context) error {
 		event, _ := cron.NewEvent(ctx)
 		r, _ := http.NewRequestWithContext(ctx, "GET", "/", nil)
-		c := NewContext(nil, r, t.env, &t.option)
+		c := t.newTaskContext(r)
 		for _, task := range scheduleTasks {
 			// When BlowActionSchedule is set, only run for the matching
 			// fired cron expression. An empty schedule runs on every event.
@@ -145,20 +147,6 @@ func (
 		}
 		return
 	}
-}
-
-func (
-	t *takibi[Bindings],
-) initializeContext(
-	w http.ResponseWriter,
-	r *http.Request,
-) interfaces.IContext[Bindings] {
-	if ctx, ok := t.cache.Get().(interfaces.IContext[Bindings]); ok {
-		ctx.Reset(w, r)
-		return ctx
-	}
-
-	return NewContext(w, r, t.Env(), &t.option)
 }
 
 func (


### PR DESCRIPTION
Closes #143

## What

`Bindings` were fixed at app construction and shared by every request, so `ctx.Env()` was never request-scoped. This adds the two layers the issue asked for, following Hono's "pass env when the context is created" (`#dispatch` → `new Context(request, { env })`).

### 1. Per-request resolver hook

- `IContext.SetEnv(env *Bindings)` — `Reset(w, r)` did not touch `env` (`context.go:56`), so a pooled context kept the previous request's env.
- `ITakibi.OnEnv(resolver EnvResolverFunc[Bindings])` where `EnvResolverFunc = func(*http.Request) *Bindings`.
- `initializeContext` now always re-assigns the env, whether the context came from the `sync.Pool` or was freshly built. Since the resolver returns a new pointer per request, a handler writing to `ctx.Env()` no longer races with concurrent requests.
- Blow tasks go through the same `resolveEnv`, so a tagged field is populated in a scheduled task too — not only in HTTP handlers.

### 2. Struct-tag standard resolver (auto injection)

New `cloudflareenv` package. The field plan is built once by reflection at `New()`; each request only fills the values.

```go
type Bindings struct {
	ApiKey string        `env:"API_KEY"`
	Store  *kv.Namespace `cfbinding:"MY_KV"`
}

app := takibi.New(&Bindings{}) // no resolver to register: New detects the tags
```

- `env` → `cloudflare.Getenv` on wasm, `os.Getenv` on native.
- `cfbinding` → `*kv.Namespace` / `*r2.Bucket` / `js.Value` on wasm, left at its zero value on native, so the same `main()` builds for both targets.
- Writing a tag is already an explicit intent, so `New` wires the resolver automatically (per the issue's recommendation). `OnEnv` replaces it. An invalid tag (`Port int \`env:"PORT"\``) panics at construction rather than failing silently on the first request.

Untagged apps that never call `OnEnv` keep the previous app-fixed env — fully backward compatible.

## Docs & template

- `_templates/cloudflare-worker`: empty `type Bindings struct{}` replaced with a tagged sample + a matching `vars` entry in `wrangler.jsonc`.
- `docs`: Workers bindings section rewritten around auto-injection, plus a "Custom Resolvers" section and a "Current Limitations" section covering the app-fixed env data race, `New(nil)`'s zero values (#123 (4)), and `Route` discarding the sub app's env.
- README gains a "Request-Scoped Bindings" section.

## Tests

TDD throughout; `cloudflareenv` is at 100% statement coverage.

- Resolver called per request with independent `ctx.Env()` across two sequential `Camp` calls (exercises the pool-reuse path).
- Unchanged behavior when no resolver is registered.
- A pooled context does not leak the previous env.
- Tag plan building (mutually exclusive tags, unexported fields, non-string `env` target, non-struct Bindings) unit-tested natively; native `env` injection e2e via `os.Getenv`; wasm compilation verified with `just build-wasm` / `just lint-wasm`.

`just ci` passes: tests, lint, wasm lint, wasm build.

## Deliberately out of scope

- Memoizing wasm bindings per isolate — that would re-introduce the shared-state assumption the issue explicitly rejects.
- Non-string `env` targets (`Port int`). `thttp.setFormField` already converts strings to scalars and could be reused; worth a follow-up.
- A registry so `cfbinding` supports D1/Queues/DO without editing the framework switch.
- Variables store (#123 (2)) and sub-app env for `Route` (#123 (3)), which the issue lists as non-goals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)